### PR TITLE
feat: User 엔티티 구현 (#21)

### DIFF
--- a/src/main/java/com/team01/deokhugam/global/entity/BaseRemovableEntity.java
+++ b/src/main/java/com/team01/deokhugam/global/entity/BaseRemovableEntity.java
@@ -12,15 +12,17 @@ public abstract class BaseRemovableEntity extends BaseUpdatableEntity {
   @Column(name = "is_deleted", nullable = false)
   private boolean isDeleted = false;
 
+  // NOTE: (추후고려사항) deletedAt이 null이면 활성, 값이 있으면 삭제됨 -> 이걸로 isDeleted 역할 대신 가능
   @Column(name = "deleted_at")
   private Instant deletedAt;
 
   // 논리 삭제 용 -> 삭제여부 O / 삭제시간 부여
+
   /**
    * Marks the entity as deleted and records the deletion timestamp.
-   *
-   * After invocation, {@code isDeleted} is set to {@code true} and {@code deletedAt}
-   * holds the current instant.
+   * <p>
+   * After invocation, {@code isDeleted} is set to {@code true} and {@code deletedAt} holds the
+   * current instant.
    */
   public void softDelete() {
     if (this.isDeleted) {

--- a/src/main/java/com/team01/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserController.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.user.controller;
+
+public class UserController {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/dto/PowerUserDto.java
+++ b/src/main/java/com/team01/deokhugam/user/dto/PowerUserDto.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.user.dto;
+
+public record PowerUserDto() {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/dto/UserDto.java
+++ b/src/main/java/com/team01/deokhugam/user/dto/UserDto.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.user.dto;
+
+public record UserDto() {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/dto/UserLoginRequest.java
+++ b/src/main/java/com/team01/deokhugam/user/dto/UserLoginRequest.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.user.dto;
+
+public record UserLoginRequest() {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/team01/deokhugam/user/dto/UserRegisterRequest.java
@@ -1,0 +1,41 @@
+package com.team01.deokhugam.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserRegisterRequest(
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    // [2, 20] characters
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 20, message = "닉네임은 2~20자 사이여야 합니다.")
+    String nickname,
+
+    // matches ^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,20}$
+
+    /*
+    ?= ...  이 위치 다음에 ... 패턴이 오는지
+    .*      임의의 문자 반복 (문자열 내의 어느 위치든 상관 없음)
+      .     아무 문자(줄바꿈 제외) 1개
+      *     0개 이상 반복
+
+    ^                         문자열 시작
+    (?=.*[A-Za-z])            문자열 전체 중 어디든 영문자 최소 1개
+    (?=.*\d)                  숫자 최소 1개
+    (?=.*[@$!%*#?&])          특수문자 최소 1개
+    [A-Za-z\d@$!%*#?&]{8,20}  허용 문자로만 8~20자 구성
+    $                         문자열 끝
+     */
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+        message = "비밀번호는 8~20자이며, 영문자, 숫자, 특수문자(@$!%*#?&)를 각각 1개 이상 포함해야 합니다."
+    )
+    String password
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/team01/deokhugam/user/dto/UserUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.user.dto;
+
+public record UserUpdateRequest() {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/entity/User.java
+++ b/src/main/java/com/team01/deokhugam/user/entity/User.java
@@ -24,10 +24,11 @@ public class User extends BaseUpdatableEntity {
   @Column(name = "email", nullable = false, unique = true)
   private String email;
 
-  @Column(name = "nickname", nullable = false)
+  @Column(name = "nickname", nullable = false, length = 20)
   private String nickname;
 
-  @Column(name = "password", nullable = false)
+  // 암호화 저장 고려 길이 100 설정
+  @Column(name = "password", nullable = false, length = 100)
   private String password;
 
   // deletedAt이 null이면 활성, 값이 있으면 삭제됨 -> 이걸로 isDeleted 역할 대신 가능

--- a/src/main/java/com/team01/deokhugam/user/entity/User.java
+++ b/src/main/java/com/team01/deokhugam/user/entity/User.java
@@ -1,10 +1,9 @@
 package com.team01.deokhugam.user.entity;
 
-import com.team01.deokhugam.global.entity.BaseUpdatableEntity;
+import com.team01.deokhugam.global.entity.BaseRemovableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,13 +12,17 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseUpdatableEntity {
+public class User extends BaseRemovableEntity {
 
   // id
 
   // createdAt
 
   // updatedAt
+
+  // isDeleted
+
+  // deletedAt
 
   @Column(name = "email", nullable = false, unique = true)
   private String email;
@@ -31,26 +34,13 @@ public class User extends BaseUpdatableEntity {
   @Column(name = "password", nullable = false, length = 100)
   private String password;
 
-  // deletedAt이 null이면 활성, 값이 있으면 삭제됨 -> 이걸로 isDeleted 역할 대신 가능
-  @Column(name = "is_deleted", nullable = false)
-  private boolean isDeleted = false;
-
-  private Instant deletedAt;
-
-  public static User create(String email, String nickname, String password) {
-    User user = new User();
-    user.email = email;
-    user.nickname = nickname;
-    user.password = password;
-    return user;
+  public User(String email, String nickname, String password) {
+    this.email = email;
+    this.nickname = nickname;
+    this.password = password;
   }
 
   public void updateNickname(String nickname) {
     this.nickname = nickname;
-  }
-
-  public void softDelete() {
-    this.deletedAt = Instant.now();
-    this.isDeleted = true;
   }
 }

--- a/src/main/java/com/team01/deokhugam/user/entity/User.java
+++ b/src/main/java/com/team01/deokhugam/user/entity/User.java
@@ -1,0 +1,55 @@
+package com.team01.deokhugam.user.entity;
+
+import com.team01.deokhugam.global.entity.BaseUpdatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseUpdatableEntity {
+
+  // id
+
+  // createdAt
+
+  // updatedAt
+
+  @Column(name = "email", nullable = false, unique = true)
+  private String email;
+
+  @Column(name = "nickname", nullable = false)
+  private String nickname;
+
+  @Column(name = "password", nullable = false)
+  private String password;
+
+  // deletedAt이 null이면 활성, 값이 있으면 삭제됨 -> 이걸로 isDeleted 역할 대신 가능
+  @Column(name = "is_deleted", nullable = false)
+  private boolean isDeleted = false;
+
+  private Instant deletedAt;
+
+  public static User create(String email, String nickname, String password) {
+    User user = new User();
+    user.email = email;
+    user.nickname = nickname;
+    user.password = password;
+    return user;
+  }
+
+  public void updateNickname(String nickname) {
+    this.nickname = nickname;
+  }
+
+  public void softDelete() {
+    this.deletedAt = Instant.now();
+    this.isDeleted = true;
+  }
+}

--- a/src/main/java/com/team01/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/team01/deokhugam/user/repository/UserRepository.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.user.repository;
+
+public class UserRepository {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/team01/deokhugam/user/service/UserService.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.user.service;
+
+public class UserService {
+
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #21 

## 📝 작업 내용

- User 엔티티 nickname, password 컬럼 길이 제약 추가 (nickname: 20, password: 100)
- UserRegisterRequest: 이메일 형식, 닉네임 2~20자, 비밀번호 정규식 검증 적용
- controller, dto, service, repository 패키지 및 빈 클래스 생성 (구조 선정의)

## 💡 변경 사항

## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 등록 기능 추가 (이메일, 닉네임, 비밀번호 포함)
  * 비밀번호 유효성 검사 구현 (8-20자, 영문, 숫자, 특수문자 필수)
  * 사용자 계정 관리 기능 기초 구현
  * 사용자 데이터 소프트 삭제 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->