### PR TITLE
chore: build.gradle Swagger 의존성 추가 및 설정 (#96)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     // Spring Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Documentation - Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+
     // MapStruct
     implementation 'org.mapstruct:mapstruct:1.6.3'
 

--- a/src/main/java/com/team01/deokhugam/global/config/SwaggerConfig.java
+++ b/src/main/java/com/team01/deokhugam/global/config/SwaggerConfig.java
@@ -20,7 +20,7 @@ public class SwaggerConfig {
         )
         .servers(List.of(
             // Swagger UI의 "Try it out" 요청이 전송될 기본 서버 주소
-            new Server().url("http://localhost:8080").description("로컬 서버")
+            new Server().url("/").description("현재 접속 서버")
         ));
   }
 }

--- a/src/main/java/com/team01/deokhugam/global/config/SwaggerConfig.java
+++ b/src/main/java/com/team01/deokhugam/global/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package com.team01.deokhugam.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("deokhugam API 문서")
+            .description("deokhugam 프로젝트의 Swagger API 문서입니다.")
+            .version("1.2")
+        )
+        .servers(List.of(
+            // Swagger UI의 "Try it out" 요청이 전송될 기본 서버 주소
+            new Server().url("http://localhost:8080").description("로컬 서버")
+        ));
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #96 

## 📝 작업 내용

- build.gradledp Swagger 의존성 추가
- springdoc-openapi가 자동 생성하는 API 문서의 메타 정보를 커스터마이징하는 설정 클래스 구현

## 💡 변경 사항

## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Swagger UI를 통한 API 문서 조회 및 테스트 기능이 추가되었습니다. API 엔드포인트를 시각적으로 확인하고 브라우저에서 직접 테스트할 수 있으며, 로컬 서버 환경에 최적화되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->