### PR TITLE
feat: 리뷰 엔티티 설계 (#36)

### DIFF
--- a/src/main/java/com/team01/deokhugam/review/dto/CursorPageResponseReviewDto.java
+++ b/src/main/java/com/team01/deokhugam/review/dto/CursorPageResponseReviewDto.java
@@ -1,0 +1,15 @@
+package com.team01.deokhugam.review.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record CursorPageResponseReviewDto(
+    List<ReviewDto> content,
+    String nextCursor,
+    OffsetDateTime nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/team01/deokhugam/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,27 @@
+package com.team01.deokhugam.review.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record ReviewCreateRequest(
+    @NotNull(message = "도서 ID는 필수입니다.")
+    UUID bookId,
+
+    @NotNull(message = "사용자 ID는 필수입니다.")
+    UUID userId,
+
+    @NotBlank(message = "리뷰 내용은 필수입니다.")
+    @Size(min = 1, max = 1000, message = "리뷰는 1~1000자 사이여야 합니다.")
+    String content,
+
+    @NotNull(message = "평점은 필수입니다.")
+    @DecimalMin(value = "1.0", message = "평점은 1.0 이상이어야 합니다.")
+    @DecimalMax(value = "5.0", message = "평점은 5.0 이하여야 합니다.")
+    Double rating
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/review/dto/ReviewDto.java
+++ b/src/main/java/com/team01/deokhugam/review/dto/ReviewDto.java
@@ -1,0 +1,22 @@
+package com.team01.deokhugam.review.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ReviewDto(
+    UUID id,
+    UUID bookId,
+    String bookTitle,
+    String bookThumbnailUrl,
+    UUID userId,
+    String userNickname,
+    String content,
+    Double rating,
+    long likeCount,
+    long commentCount,
+    boolean likedByMe,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/review/dto/ReviewLikeDto.java
+++ b/src/main/java/com/team01/deokhugam/review/dto/ReviewLikeDto.java
@@ -1,0 +1,11 @@
+package com.team01.deokhugam.review.dto;
+
+import java.util.UUID;
+
+public record ReviewLikeDto(
+    UUID reviewId,
+    UUID userId,
+    boolean liked
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/review/dto/ReviewUpdateRequest.java
+++ b/src/main/java/com/team01/deokhugam/review/dto/ReviewUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.team01.deokhugam.review.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReviewUpdateRequest(
+    @NotBlank(message = "리뷰 내용은 필수입니다.")
+    @Size(min = 1, max = 1000, message = "리뷰는 1~1000자 사이여야 합니다.")
+    String content,
+
+    @NotNull(message = "평점은 필수입니다.")
+    @DecimalMin(value = "1.0", message = "평점은 1.0 이상이어야 합니다.")
+    @DecimalMax(value = "5.0", message = "평점은 5.0 이하여야 합니다.")
+    Double rating
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/team01/deokhugam/review/entity/Review.java
@@ -1,0 +1,91 @@
+package com.team01.deokhugam.review.entity;
+
+import com.team01.deokhugam.global.entity.BaseRemovableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    name = "reviews",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_review_book_user",
+            columnNames = {"book_id", "user_id"}
+        )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseRemovableEntity {
+
+  //도서 ID
+  @Column(name = "book_id", nullable = false)
+  private UUID bookId;
+
+  // 작성자 ID
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  // 리뷰 내용
+  @Column(name = "content", nullable = false, length = 1000)
+  private String content;
+
+  // 평점(1.0~5.0)
+  @Column(name = "rating", nullable = false)
+  private Double rating;
+
+  // 좋아요 수
+  @Column(name = "like_count", nullable = false)
+  private long likeCount;
+
+  // 댓글 수
+  @Column(name = "comment_count", nullable = false)
+  private long commentCount;
+
+  public Review(UUID bookId, UUID userId, String content, Double rating) {
+    this.bookId = bookId;
+    this.userId = userId;
+    this.content = content;
+    this.rating = rating;
+    this.likeCount = 0L;
+    this.commentCount = 0L;
+  }
+
+  // 리뷰 내용/평점 수정
+  public void update(String content, Double rating) {
+    this.content = content;
+    this.rating = rating;
+  }
+
+  // 좋아요 수 증가
+  public void increaseLikeCount() {
+    this.likeCount++;
+  }
+
+  // 좋아요 수 감소
+  public void decreaseLikeCount() {
+    if (this.likeCount > 0) {
+      this.likeCount--;
+    }
+  }
+
+  // 댓글 수 증가
+  public void increaseCommentCount() {
+    this.commentCount++;
+  }
+
+  // 댓글 수 감소
+  public void decreaseCommentCount() {
+    if (this.commentCount > 0) {
+      this.commentCount--;
+    }
+  }
+
+
+}

--- a/src/main/java/com/team01/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/team01/deokhugam/review/entity/Review.java
@@ -4,7 +4,8 @@ import com.team01.deokhugam.global.entity.BaseRemovableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,80 +13,102 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(
-    name = "reviews",
-    uniqueConstraints = {
-        @UniqueConstraint(
-            name = "uk_review_book_user",
-            columnNames = {"book_id", "user_id"}
-        )
-    }
-)
+@Table(name = "reviews")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseRemovableEntity {
 
-  //도서 ID
   @Column(name = "book_id", nullable = false)
   private UUID bookId;
 
-  // 작성자 ID
   @Column(name = "user_id", nullable = false)
   private UUID userId;
 
-  // 리뷰 내용
   @Column(name = "content", nullable = false, length = 1000)
   private String content;
 
-  // 평점(1.0~5.0)
   @Column(name = "rating", nullable = false)
   private Double rating;
 
-  // 좋아요 수
   @Column(name = "like_count", nullable = false)
   private long likeCount;
 
-  // 댓글 수
   @Column(name = "comment_count", nullable = false)
   private long commentCount;
 
+  @Version
+  @Column(name = "version", nullable = false)
+  private Long version;
+
   public Review(UUID bookId, UUID userId, String content, Double rating) {
+    validateBookId(bookId);
+    validateUserId(userId);
+    validateContent(content);
+    validateRating(rating);
+
     this.bookId = bookId;
     this.userId = userId;
-    this.content = content;
+    this.content = content.trim();
     this.rating = rating;
     this.likeCount = 0L;
     this.commentCount = 0L;
   }
 
-  // 리뷰 내용/평점 수정
   public void update(String content, Double rating) {
-    this.content = content;
+    validateContent(content);
+    validateRating(rating);
+
+    this.content = content.trim();
     this.rating = rating;
   }
 
-  // 좋아요 수 증가
   public void increaseLikeCount() {
     this.likeCount++;
   }
 
-  // 좋아요 수 감소
   public void decreaseLikeCount() {
     if (this.likeCount > 0) {
       this.likeCount--;
     }
   }
 
-  // 댓글 수 증가
   public void increaseCommentCount() {
     this.commentCount++;
   }
 
-  // 댓글 수 감소
   public void decreaseCommentCount() {
     if (this.commentCount > 0) {
       this.commentCount--;
     }
   }
 
+  private void validateBookId(UUID bookId) {
+    Objects.requireNonNull(bookId, "도서 ID는 null일 수 없습니다.");
+  }
 
+  private void validateUserId(UUID userId) {
+    Objects.requireNonNull(userId, "사용자 ID는 null일 수 없습니다.");
+  }
+
+  private void validateContent(String content) {
+    if (content == null) {
+      throw new IllegalArgumentException("리뷰 내용은 null일 수 없습니다.");
+    }
+
+    String trimmedContent = content.trim();
+
+    if (trimmedContent.isEmpty()) {
+      throw new IllegalArgumentException("리뷰 내용은 비어 있을 수 없습니다.");
+    }
+
+    if (trimmedContent.length() > 1000) {
+      throw new IllegalArgumentException("리뷰는 1000자를 초과할 수 없습니다.");
+    }
+  }
+
+  private void validateRating(Double rating) {
+    Objects.requireNonNull(rating, "평점은 null일 수 없습니다.");
+    if (rating < 1.0 || rating > 5.0) {
+      throw new IllegalArgumentException("평점은 1.0 이상 5.0 이하여야 합니다.");
+    }
+  }
 }

--- a/src/main/java/com/team01/deokhugam/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/team01/deokhugam/review/mapper/ReviewMapper.java
@@ -1,0 +1,21 @@
+package com.team01.deokhugam.review.mapper;
+
+import com.team01.deokhugam.review.dto.ReviewDto;
+import com.team01.deokhugam.review.entity.Review;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ReviewMapper {
+
+  @Mapping(target = "bookTitle", ignore = true)
+  @Mapping(target = "bookThumbnailUrl", ignore = true)
+  @Mapping(target = "userNickname", ignore = true)
+  @Mapping(target = "likedByMe", ignore = true)
+  @Mapping(target = "updatedAt", source = "updatedAt")
+  ReviewDto toDto(Review review);
+
+  List<ReviewDto> toDtoList(List<Review> reviews);
+
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #36 

## 📝 작업 내용

- 리뷰 엔티티를 설계했습니다.
- 도서별 사용자 1개 리뷰 등록 제한을 위해 `book_id`, `user_id` 유니크 제약 조건을 추가했습니다.
- 리뷰 내용, 평점, 좋아요 수, 댓글 수 필드를 포함하도록 구성했습니다.
- 리뷰 수정, 좋아요 수 증감, 댓글 수 증감 메서드를 추가했습니다.
- 논리 삭제 정책에 맞게 `BaseRemovableEntity`를 상속하도록 구성했습니다.

## 💡 변경 사항

- `Review` 엔티티를 추가했습니다.
- 리뷰 생성 시 좋아요 수와 댓글 수가 0으로 초기화되도록 했습니다.
- 댓글 수 감소 로직이 `commentCount`를 감소시키도록 수정했습니다.

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 리뷰 작성, 수정 및 좋아요 기능 추가
* 리뷰 평점 지원 (1.0~5.0점)
* 리뷰 목록 커서 기반 페이지네이션 지원
* 리뷰 내용 및 평점 유효성 검증 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->