### PR TITLE
fix: Auditing 시 OffsetDateTime.now()를 사용하도록 강제 (#112)

### DIFF
--- a/src/main/java/com/team01/deokhugam/global/config/JpaConfig.java
+++ b/src/main/java/com/team01/deokhugam/global/config/JpaConfig.java
@@ -1,8 +1,19 @@
 package com.team01.deokhugam.global.config;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
-public class JpaConfig {}
+@EnableJpaAuditing(dateTimeProviderRef = "offsetDateTimeProvider")
+public class JpaConfig {
+
+  @Bean
+  public DateTimeProvider offsetDateTimeProvider() {
+    // Auditing 시 OffsetDateTime.now()를 사용하도록 강제
+    return () -> Optional.of(OffsetDateTime.now());
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #112 

## 📝 작업 내용

- 필드 타입이 OffsetDateTime인데 Spring Data Auditing이 LocalDateTime을 주입하려 해서 발생하는 이슈 해결용
- JpaConfig.java에서 Auditing 시 OffsetDateTime.now()를 사용하도록 강제

## 💡 변경 사항

## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 시스템 타임스탬프 기록의 정확성 및 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->