### PR TITLE
feat: 사용자 CURD 테스트 코드 추가 및 사용자 본인 확인 검증 로직 추가

### DIFF
--- a/src/main/java/com/team01/deokhugam/global/constant/AuthHeader.java
+++ b/src/main/java/com/team01/deokhugam/global/constant/AuthHeader.java
@@ -1,0 +1,9 @@
+package com.team01.deokhugam.global.constant;
+
+public final class AuthHeader {
+
+  public static final String REQUEST_USER_ID = "Deokhugam-Request-User-ID";
+
+  private AuthHeader() {
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
@@ -24,7 +24,9 @@ public enum ErrorCode {
   // user
   EMAIL_ALREADY_EXISTS(409, "EMAIL_ALREADY_EXISTS", "이미 등록된 이메일입니다."),
   USER_NOT_FOUND(404, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
-  LOGIN_FAILED(401, "LOGIN_FAILED", "이메일 또는 비밀번호가 일치하지 않습니다.");
+  LOGIN_FAILED(401, "LOGIN_FAILED", "이메일 또는 비밀번호가 일치하지 않습니다."),
+  USER_ACCESS_DENIED(403, "USER_ACCESS_DENIED", "해당 사용자에 대한 권한이 없습니다."),
+  MISSING_REQUEST_USER_ID(400, "MISSING_REQUEST_USER_ID", "요청자 ID가 누락되었습니다.");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/team01/deokhugam/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/GlobalExceptionHandler.java
@@ -1,15 +1,21 @@
 package com.team01.deokhugam.global.exception;
 
+import com.team01.deokhugam.global.constant.AuthHeader;
+import java.time.Instant;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+
   @ExceptionHandler(DeokhugamException.class)
-  public ResponseEntity<ErrorResponse> handleDeokhugamException(DeokhugamException e){
+  public ResponseEntity<ErrorResponse> handleDeokhugamException(DeokhugamException e) {
     ErrorCode errorCode = e.getErrorCode();
 
     log.warn(" [Domain Error] Code: {}, Message: {}, Details: {}",
@@ -26,6 +32,43 @@ public class GlobalExceptionHandler {
         errorCode.getStatus()
     );
     return ResponseEntity.status(response.getStatus()).body(response);
+  }
+
+  // ServletException 처리 - 체크드 예외 (Checked Exception)
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ErrorResponse> handleMissingRequestHeader(MissingRequestHeaderException e) {
+    // REQUEST_USER_ID 누락
+    if (AuthHeader.REQUEST_USER_ID.equals(e.getHeaderName())) {
+      ErrorCode errorCode = ErrorCode.MISSING_REQUEST_USER_ID;
+
+      log.warn(" [Missing Header] Code: {}, Message: {}, Header: {}",
+          errorCode.getCode(),
+          errorCode.getMessage(),
+          e.getHeaderName());
+
+      ErrorResponse response = new ErrorResponse(
+          Instant.now(),
+          errorCode.getCode(),
+          errorCode.getMessage(),
+          Map.of("headerName", e.getHeaderName()),
+          e.getClass().getSimpleName(),
+          errorCode.getStatus()
+      );
+      return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    // 그 외 헤더 누락 -> 일반 400
+    log.warn(" [Missing Header] {}", e.getMessage());
+
+    ErrorResponse response = new ErrorResponse(
+        Instant.now(),
+        "MISSING_REQUEST_HEADER",
+        "필수 헤더가 누락되었습니다.",
+        Map.of("headerName", e.getHeaderName()),
+        e.getClass().getSimpleName(),
+        400
+    );
+    return ResponseEntity.badRequest().body(response);
   }
 
 }

--- a/src/main/java/com/team01/deokhugam/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingRequestHeaderException;
-import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -35,7 +34,7 @@ public class GlobalExceptionHandler {
   }
 
   // ServletException 처리 - 체크드 예외 (Checked Exception)
-  @ExceptionHandler(MissingServletRequestParameterException.class)
+  @ExceptionHandler(MissingRequestHeaderException.class)
   public ResponseEntity<ErrorResponse> handleMissingRequestHeader(MissingRequestHeaderException e) {
     // REQUEST_USER_ID 누락
     if (AuthHeader.REQUEST_USER_ID.equals(e.getHeaderName())) {

--- a/src/main/java/com/team01/deokhugam/global/exception/user/UserAccessDeniedException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/user/UserAccessDeniedException.java
@@ -1,0 +1,19 @@
+package com.team01.deokhugam.global.exception.user;
+
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class UserAccessDeniedException extends UserException {
+
+  public UserAccessDeniedException(UUID pathUserId, UUID requestUserId) {
+    super(
+        ErrorCode.USER_ACCESS_DENIED,
+        Map.of(
+            "resourceId", pathUserId.toString(), // 접근하려는 대상의 리소스 소유자 ID
+            "requestUserId", requestUserId.toString(), // 실제 요청을 보낸 사용자 ID
+            "operation", "VERIFY_SELF"
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
@@ -100,7 +100,12 @@ public interface UserApi {
       @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })
   ResponseEntity<Void> deleteUser(
-      @Parameter(description = "삭제할 사용자 ID") UUID userId
+      @Parameter(description = "삭제할 사용자 ID") UUID userId,
+      @Parameter(
+          name = "Deokhugam-Request-User-ID",
+          description = "요청자 ID",
+          required = true
+      ) UUID requestUserId
   );
 
   /// PATCH - /api/users/{userId} - 사용자 정보 수정
@@ -127,6 +132,11 @@ public interface UserApi {
   ResponseEntity<UserDto> updateUser(
       @Parameter(description = "수정할 사용자 ID") UUID userId,
       @Parameter(
+          name = "Deokhugam-Request-User-ID",
+          description = "요청자 ID",
+          required = true
+      ) UUID requestUserId,
+      @Parameter(
           description = "수정할 사용자 정보",
           content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
       ) @Valid UserUpdateRequest request
@@ -149,6 +159,11 @@ public interface UserApi {
       @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })
   ResponseEntity<Void> permanentDeleteUser(
-      @Parameter(description = "물리 삭제할 사용자 ID") UUID userId
+      @Parameter(description = "물리 삭제할 사용자 ID") UUID userId,
+      @Parameter(
+          name = "Deokhugam-Request-User-ID",
+          description = "요청자 ID",
+          required = true
+      ) UUID requestUserId
   );
 }

--- a/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
@@ -6,6 +6,7 @@ import com.team01.deokhugam.user.dto.UserRegisterRequest;
 import com.team01.deokhugam.user.dto.UserUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -103,6 +104,7 @@ public interface UserApi {
       @Parameter(description = "삭제할 사용자 ID") UUID userId,
       @Parameter(
           name = "Deokhugam-Request-User-ID",
+          in = ParameterIn.HEADER,
           description = "요청자 ID",
           required = true
       ) UUID requestUserId
@@ -133,6 +135,7 @@ public interface UserApi {
       @Parameter(description = "수정할 사용자 ID") UUID userId,
       @Parameter(
           name = "Deokhugam-Request-User-ID",
+          in = ParameterIn.HEADER,
           description = "요청자 ID",
           required = true
       ) UUID requestUserId,
@@ -162,6 +165,7 @@ public interface UserApi {
       @Parameter(description = "물리 삭제할 사용자 ID") UUID userId,
       @Parameter(
           name = "Deokhugam-Request-User-ID",
+          in = ParameterIn.HEADER,
           description = "요청자 ID",
           required = true
       ) UUID requestUserId

--- a/src/main/java/com/team01/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.team01.deokhugam.user.controller;
 
+import com.team01.deokhugam.global.constant.AuthHeader;
+import com.team01.deokhugam.global.exception.user.UserAccessDeniedException;
 import com.team01.deokhugam.user.dto.UserDto;
 import com.team01.deokhugam.user.dto.UserLoginRequest;
 import com.team01.deokhugam.user.dto.UserRegisterRequest;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -61,7 +64,11 @@ public class UserController implements UserApi {
 
   /// DELETE - /api/users/{userId} - 사용자 논리 삭제
   @DeleteMapping("/{userId}")
-  public ResponseEntity<Void> deleteUser(@PathVariable UUID userId) {
+  public ResponseEntity<Void> deleteUser(
+      @PathVariable UUID userId,
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId
+  ) {
+    verifySelf(userId, requestUserId);
     log.info("사용자 논리 삭제 요청");
     userService.deleteUser(userId);
     log.info("사용자 논리 삭제 완료");
@@ -74,8 +81,10 @@ public class UserController implements UserApi {
   @PatchMapping("/{userId}")
   public ResponseEntity<UserDto> updateUser(
       @PathVariable UUID userId,
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId,
       @Valid @RequestBody UserUpdateRequest request
   ) {
+    verifySelf(userId, requestUserId);
     log.info("사용자 정보 수정 요청");
     UserDto result = userService.updateUser(userId, request);
     log.info("사용자 정보 수정 완료");
@@ -86,12 +95,22 @@ public class UserController implements UserApi {
 
   /// DELETE - /api/users/{userId}/hard - 사용자 물리 삭제
   @DeleteMapping("/{userId}/hard")
-  public ResponseEntity<Void> permanentDeleteUser(@PathVariable UUID userId) {
+  public ResponseEntity<Void> permanentDeleteUser(
+      @PathVariable UUID userId,
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId
+  ) {
+    verifySelf(userId, requestUserId);
     log.warn("사용자 물리 삭제 요청");
     userService.permanentDeleteUser(userId);
     log.warn("사용자 물리 삭제 완료");
     return ResponseEntity
         .noContent()
         .build();
+  }
+
+  private void verifySelf(UUID pathUserId, UUID requestUserId) {
+    if (!pathUserId.equals(requestUserId)) {
+      throw new UserAccessDeniedException(pathUserId, requestUserId);
+    }
   }
 }

--- a/src/test/java/com/team01/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/user/controller/UserControllerTest.java
@@ -1,0 +1,111 @@
+package com.team01.deokhugam.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team01.deokhugam.global.constant.AuthHeader;
+import com.team01.deokhugam.user.dto.UserDto;
+import com.team01.deokhugam.user.dto.UserUpdateRequest;
+import com.team01.deokhugam.user.service.UserService;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+// Spring MVC 계층만 로드하는 슬라이스 테스트
+@WebMvcTest(UserController.class)
+@DisplayName("UserController")
+class UserControllerTest {
+
+  // MockMvc: Spring MVC 테스트를 위한 도구
+  @Autowired
+  private MockMvc mockMvc;
+
+  // ObjectMapper: Jackson의 JSON 직렬화/역직렬화 도구
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private UserService userService;
+
+  @Nested
+  @DisplayName("PATCH /api/users/{userId} - 사용자 정보 수정")
+  class UpdateUser {
+
+    @Test
+    @DisplayName("성공 - 본인 요청, 유효한 닉네임")
+    void updateUser_Success() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      String newNickname = "변경된닉네임";
+      UserUpdateRequest request = new UserUpdateRequest(newNickname);
+      UserDto response = new UserDto(userId, "test@email.com", newNickname, OffsetDateTime.now());
+      given(userService.updateUser(eq(userId), any(UserUpdateRequest.class))).willReturn(response);
+
+      // when & then
+      mockMvc.perform(patch("/api/users/{userId}", userId)
+              .header(AuthHeader.REQUEST_USER_ID, userId.toString())
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request))) // UserUpdateRequest를 JSON으로 직렬화
+          // 응답 상태 코드가 200 OK인지 검증
+          .andExpect(status().isOk())
+          // 응답 JSON의 id 필드가 userId와 일치하는지 검증
+          .andExpect(jsonPath("$.id").value(userId.toString()))
+          // 응답 JSON의 nickname 필드가 변경된 닉네임과 일치하는지 검증
+          .andExpect(jsonPath("$.nickname").value(newNickname));
+
+      // updateUser()가 1번 호출되었는지 확인
+      verify(userService).updateUser(eq(userId), any(UserUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("실패(403) - 본인 아님: path userId와 헤더 userId 불일치")
+    void updateUser_Fail_AccessDenied() throws Exception {
+      // given
+      UUID pathUserId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+      UserUpdateRequest request = new UserUpdateRequest("변경된닉네임");
+
+      // when & then
+      mockMvc.perform(patch("/api/users/{userId}", pathUserId)
+              // 헤더에 다른 사용자의 ID를 넣음 -> 본인이 아님
+              .header(AuthHeader.REQUEST_USER_ID, requestUserId.toString())
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isForbidden());
+
+      // Service가 호출되지 않았음을 검증
+      verify(userService, never()).updateUser(any(UUID.class), any(UserUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("실패(400) - 요청자 헤더 누락")
+    void updateUser_Fail_MissingHeader() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      UserUpdateRequest request = new UserUpdateRequest("변경된닉네임");
+
+      // when & then
+      mockMvc.perform(patch("/api/users/{userId}", userId)
+              // 헤더를 넣지 않음 -> 누락
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+
+      verify(userService, never()).updateUser(any(UUID.class), any(UserUpdateRequest.class));
+    }
+  }
+}

--- a/src/test/java/com/team01/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/user/controller/UserControllerTest.java
@@ -103,7 +103,9 @@ class UserControllerTest {
               // 헤더를 넣지 않음 -> 누락
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isBadRequest());
+          .andExpect(status().isBadRequest())
+          // ErrorCode가 MISSING_REQUEST_USER_ID 인지 검증 (GlobalExceptionHandler에서 제대로 잡히는지 확인)
+          .andExpect(jsonPath("$.code").value("MISSING_REQUEST_USER_ID"));
 
       verify(userService, never()).updateUser(any(UUID.class), any(UserUpdateRequest.class));
     }

--- a/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
@@ -153,4 +153,42 @@ class UserServiceTest {
           .isInstanceOf(UserNotFoundException.class);
     }
   }
+
+  @Nested
+  @DisplayName("deleteUser - 사용자 논리 삭제")
+  class DeleteUser {
+
+    @Test
+    @DisplayName("사용자 논리 삭제 성공")
+    void deleteUser_Success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.findByIdAndDeletedAtIsNull(userId)).willReturn(Optional.of(savedUser));
+
+      // when
+      userService.deleteUser(userId);
+
+      // then
+      assertThat(savedUser.isDeleted()).isTrue();
+      assertThat(savedUser.getDeletedAt()).isNotNull();
+      // save()를 명시적으로 호출하지 않았는지 검증 (더티 체킹 검증용)
+      verify(userRepository, never()).save(any(User.class));
+      // delete()를 호출하지 않았는지 검증 (논리 삭제이므로 물리 삭제가 발생하면 안됨)
+      verify(userRepository, never()).delete(any(User.class));
+    }
+
+    @Test
+    @DisplayName("사용자 논리 삭제 실패 - 존재하지 않는 사용자")
+    void deleteUser_Fail_UserNotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.findByIdAndDeletedAtIsNull(userId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> userService.deleteUser(userId))
+          .isInstanceOf(UserNotFoundException.class);
+
+      verify(userRepository, never()).delete(any(User.class));
+    }
+  }
 }

--- a/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
@@ -9,8 +9,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.team01.deokhugam.global.exception.user.EmailAlreadyExistsException;
+import com.team01.deokhugam.global.exception.user.LoginFailedException;
 import com.team01.deokhugam.global.exception.user.UserNotFoundException;
 import com.team01.deokhugam.user.dto.UserDto;
+import com.team01.deokhugam.user.dto.UserLoginRequest;
 import com.team01.deokhugam.user.dto.UserRegisterRequest;
 import com.team01.deokhugam.user.dto.UserUpdateRequest;
 import com.team01.deokhugam.user.entity.User;
@@ -113,6 +115,69 @@ class UserServiceTest {
       // 중복이면 인코딩/저장은 실행되지 않아야 함
       verify(passwordEncoder, never()).encode(anyString());
       verify(userRepository, never()).save(any(User.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("login - 로그인")
+  class Login {
+
+    private UserLoginRequest userLoginRequest;
+
+    @BeforeEach
+    void setUp() {
+      userLoginRequest = new UserLoginRequest(TEST_EMAIL, TEST_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("로그인 성공 - 이메일과 비밀번호 일치")
+    void login_Success() {
+      // given
+      given(userRepository.findByEmailAndDeletedAtIsNull(TEST_EMAIL))
+          .willReturn(Optional.of(savedUser));
+      given(passwordEncoder.matches(TEST_PASSWORD, ENCODED_PASSWORD)).willReturn(true);
+
+      // when
+      UserDto result = userService.login(userLoginRequest);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.email()).isEqualTo(TEST_EMAIL);
+      assertThat(result.nickname()).isEqualTo(TEST_NICKNAME);
+
+      // 올바른 인자로 호출되었는지 검증
+      verify(userRepository).findByEmailAndDeletedAtIsNull(TEST_EMAIL);
+      verify(passwordEncoder).matches(TEST_PASSWORD, ENCODED_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 존재하지 않거나 탈퇴한 이메일")
+    void login_Fail_EmailNotFound() {
+      // given
+      given(userRepository.findByEmailAndDeletedAtIsNull(TEST_EMAIL))
+          .willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> userService.login(userLoginRequest))
+          .isInstanceOf(LoginFailedException.class);
+
+      // 사용자 조회 실패 시 비밀번호 검증은 수행되지 않아야 함
+      verify(passwordEncoder, never()).matches(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void login_Fail_PasswordMismatch() {
+      // given
+      given(userRepository.findByEmailAndDeletedAtIsNull(TEST_EMAIL))
+          .willReturn(Optional.of(savedUser));
+      given(passwordEncoder.matches(TEST_PASSWORD, ENCODED_PASSWORD)).willReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> userService.login(userLoginRequest))
+          .isInstanceOf(LoginFailedException.class);
+
+      verify(passwordEncoder).matches(TEST_PASSWORD, ENCODED_PASSWORD);
     }
   }
 

--- a/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
@@ -182,6 +182,43 @@ class UserServiceTest {
   }
 
   @Nested
+  @DisplayName("getUser - 사용자 조회")
+  class GetUser {
+
+    @Test
+    @DisplayName("사용자 조회 성공 - 존재하는 사용자")
+    void getUser_Success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.findByIdAndDeletedAtIsNull(userId))
+          .willReturn(Optional.of(savedUser));
+
+      // when
+      UserDto result = userService.getUser(userId);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.email()).isEqualTo(TEST_EMAIL);
+      assertThat(result.nickname()).isEqualTo(TEST_NICKNAME);
+
+      verify(userRepository).findByIdAndDeletedAtIsNull(userId);
+    }
+
+    @Test
+    @DisplayName("사용자 조회 실패 - 존재하지 않거나 탈퇴한 사용자")
+    void getUser_Fail_UserNotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.findByIdAndDeletedAtIsNull(userId))
+          .willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> userService.getUser(userId))
+          .isInstanceOf(UserNotFoundException.class);
+    }
+  }
+
+  @Nested
   @DisplayName("updateUser - 사용자 정보 수정")
   class UpdateUser {
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #61 , #62 

## 📝 작업 내용

- 사용자 조회 서비스 테스트 추가
- 로그인 서비스 테스트 추가
- 사용자 논리 삭제 서비스 테스트 추가
- 사용자 정보 수정 본인 확인 테스트 추가
- 사용자 본인 확인 검증 로직 추가
  - 요청 헤더(Deokhugam-Request-User-ID)와 경로의 userId를 비교해 본인이 아닐 경우 UserAccessDeniedException(403)을 발생
  - deleteUser/updateUser/permanentDeleteUser에 verifySelf 검증을 적용
  - 관련 ErrorCode(USER_ACCESS_DENIED, MISSING_REQUEST_USER_ID) 및 헤더 상수 AuthHeader 추가

## 💡 변경 사항

- 요청자 ID 헤더는 상수로 통일
  - Deokhugam-Request-User-ID 헤더를 컨트롤러마다 문자열 리터럴로 직접 쓰고 있어서, AuthHeader 상수를 만들었습니다. (오타로 인한 버그 방지)
  - src/main/java/com/team01/deokhugam/global/constant/AuthHeader.java
해당 파일 내용 참고해서 수정 부탁드립니다.

## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 수정·삭제 요청에 요청자 ID 헤더 검증 추가 — 본인 계정만 조작 가능.
  * 누락된 요청자 ID에 대한 명확한 오류 응답 추가.

* **Bug Fixes**
  * 권한 불일치 시 접근 거부(403) 처리 추가.

* **Tests**
  * 컨트롤러·서비스 단위 테스트 보강(헤더 검증, 접근 거부, 누락 헤더 시나리오 포함).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->