### PR TITLE
feat:알림 관리 조회 메서드 추가 및 레포지토리 인터페이스 수정

### DIFF
--- a/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
@@ -4,15 +4,44 @@ import com.team01.deokhugam.notification.entity.Notification;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
 
-  Page<Notification> findAllByUserId(UUID userId, Pageable pageable);
   List<Notification> findAllByUserIdAndIsReadFalse(UUID userId);
   void deleteAllByIsReadTrueAndUpdatedAtBefore(OffsetDateTime cutoff);
+
+  @Query("""
+      SELECT n FROM Notification n
+      JOIN FETCH n.user
+      JOIN FETCH n.review
+      WHERE n.user.id = :userId
+      ORDER BY n.createdAt DESC
+      """)
+  List<Notification> findByUserIdOrderByCreatedAtDesc(
+      @Param("userId") UUID userId,
+      Pageable pageable
+  );
+
+  @Query("""
+        SELECT n FROM Notification n
+        JOIN FETCH n.user
+        JOIN FETCH n.review
+        WHERE n.user.id = :userId
+          AND n.createdAt < :after
+        ORDER BY n.createdAt DESC
+        """)
+  List<Notification> findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(
+      @Param("userId") UUID userId,
+      @Param("after") OffsetDateTime after,
+      Pageable pageable
+  );
+
+  long countByUserId(UUID userId);
+
 
 
 

--- a/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
@@ -19,7 +19,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       JOIN FETCH n.user
       JOIN FETCH n.review
       WHERE n.user.id = :userId
-      ORDER BY n.createdAt DESC
+      ORDER BY n.createdAt DESC, n.id DESC
       """)
   List<Notification> findByUserIdOrderByCreatedAtDesc(
       @Param("userId") UUID userId,
@@ -27,22 +27,20 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   );
 
   @Query("""
-        SELECT n FROM Notification n
-        JOIN FETCH n.user
-        JOIN FETCH n.review
-        WHERE n.user.id = :userId
-          AND n.createdAt < :after
-        ORDER BY n.createdAt DESC
-        """)
+      SELECT n FROM Notification n
+      JOIN FETCH n.user
+      JOIN FETCH n.review
+      WHERE n.user.id = :userId
+      AND (n.createdAt < :after
+      OR (n.createdAt = :after AND n.id < :cursor))
+      ORDER BY n.createdAt DESC, n.id DESC
+      """)
   List<Notification> findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(
       @Param("userId") UUID userId,
       @Param("after") OffsetDateTime after,
+      @Param("cursor") UUID cursor,
       Pageable pageable
   );
 
   long countByUserId(UUID userId);
-
-
-
-
 }

--- a/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
@@ -2,6 +2,7 @@ package com.team01.deokhugam.notification.service;
 
 import com.team01.deokhugam.global.pagination.CursorPageRequest;
 import com.team01.deokhugam.global.pagination.CursorPageResponse;
+import com.team01.deokhugam.global.pagination.CursorPaginationUtils;
 import com.team01.deokhugam.notification.dto.NotificationCreateRequest;
 import com.team01.deokhugam.notification.dto.NotificationDto;
 import com.team01.deokhugam.notification.entity.Notification;
@@ -14,6 +15,7 @@ import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,6 +86,45 @@ public class NotificationServiceImpl implements NotificationService {
 
   @Override
   public CursorPageResponse<NotificationDto> findAll(UUID userId, CursorPageRequest request) {
-    return null;
+    log.info("[FIND_ALL_NOTIFICATION] 알림 목록 조회 시작 userId={}, after={}, limit={}",
+        userId, request.after(), request.limit());
+    PageRequest pageable = PageRequest.of(0, request.limit() + 1);
+
+    List<Notification> results;
+
+    if (request.after() == null) {
+      log.info("[FIND_ALL_NOTIFICATION] 첫 페이지 조회 userId={}", userId);
+      results = notificationRepository
+          .findByUserIdOrderByCreatedAtDesc(userId, pageable);
+    } else {
+      log.info("[FIND_ALL_NOTIFICATION] 다음 페이지 조회 userId={}, after={}", userId, request.after());
+      results = notificationRepository
+          .findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(userId, request.after(), pageable);
+    }
+
+    log.info("[FIND_ALL_NOTIFICATION] 조회 완료 userId={}, 조회된 개수={}", userId, results.size());
+
+    long totalElements = notificationRepository.countByUserId(userId);
+
+    List<NotificationDto> dtoList = results.stream()
+        .map(n -> new NotificationDto(
+            n.getId(),
+            n.getUser().getId(),
+            n.getReview().getId(),
+            n.getReview().getContent(),
+            n.getContent(),
+            n.isRead(),
+            n.getCreatedAt(),
+            n.getUpdatedAt()
+        ))
+        .toList();
+
+    return CursorPaginationUtils.of(
+        dtoList,
+        request.limit(),
+        totalElements,
+        dto -> dto.id().toString(),
+        NotificationDto::createdAt
+    );
   }
 }

--- a/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
@@ -3,6 +3,7 @@ package com.team01.deokhugam.notification.service;
 import com.team01.deokhugam.global.pagination.CursorPageRequest;
 import com.team01.deokhugam.global.pagination.CursorPageResponse;
 import com.team01.deokhugam.global.pagination.CursorPaginationUtils;
+import com.team01.deokhugam.global.pagination.PageLimitPolicy;
 import com.team01.deokhugam.notification.dto.NotificationCreateRequest;
 import com.team01.deokhugam.notification.dto.NotificationDto;
 import com.team01.deokhugam.notification.entity.Notification;
@@ -85,10 +86,13 @@ public class NotificationServiceImpl implements NotificationService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public CursorPageResponse<NotificationDto> findAll(UUID userId, CursorPageRequest request) {
     log.info("[FIND_ALL_NOTIFICATION] 알림 목록 조회 시작 userId={}, after={}, limit={}",
         userId, request.after(), request.limit());
-    PageRequest pageable = PageRequest.of(0, request.limit() + 1);
+
+    int normalizedLimit = PageLimitPolicy.normalize(request.limit());
+    PageRequest pageable = PageRequest.of(0,  normalizedLimit + 1);
 
     List<Notification> results;
 
@@ -99,7 +103,8 @@ public class NotificationServiceImpl implements NotificationService {
     } else {
       log.info("[FIND_ALL_NOTIFICATION] 다음 페이지 조회 userId={}, after={}", userId, request.after());
       results = notificationRepository
-          .findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(userId, request.after(), pageable);
+          .findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(
+              userId, request.after(), UUID.fromString(request.cursor()), pageable);
     }
 
     log.info("[FIND_ALL_NOTIFICATION] 조회 완료 userId={}, 조회된 개수={}", userId, results.size());
@@ -121,7 +126,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     return CursorPaginationUtils.of(
         dtoList,
-        request.limit(),
+        normalizedLimit,
         totalElements,
         dto -> dto.id().toString(),
         NotificationDto::createdAt

--- a/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
@@ -97,6 +97,9 @@ public class NotificationServiceImpl implements NotificationService {
     List<Notification> results;
 
     if (request.after() == null) {
+      if (request.cursor() != null && !request.cursor().isBlank()) {
+        throw new IllegalArgumentException("cursor 가 지정된 경우 after 도 필수입니다.");
+      }
       log.info("[FIND_ALL_NOTIFICATION] 첫 페이지 조회 userId={}", userId);
       results = notificationRepository
           .findByUserIdOrderByCreatedAtDesc(userId, pageable);

--- a/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
@@ -92,7 +92,7 @@ public class NotificationServiceImpl implements NotificationService {
         userId, request.after(), request.limit());
 
     int normalizedLimit = PageLimitPolicy.normalize(request.limit());
-    PageRequest pageable = PageRequest.of(0,  normalizedLimit + 1);
+    PageRequest pageable = PageRequest.of(0, normalizedLimit + 1);
 
     List<Notification> results;
 
@@ -101,10 +101,19 @@ public class NotificationServiceImpl implements NotificationService {
       results = notificationRepository
           .findByUserIdOrderByCreatedAtDesc(userId, pageable);
     } else {
+      if (request.cursor() == null || request.cursor().isBlank()) {
+        throw new IllegalArgumentException("after 가 지정된 경우 cursor 는 필수입니다.");
+      }
+      UUID cursorId;
+      try {
+        cursorId = UUID.fromString(request.cursor());
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("cursor 형식이 올바르지 않습니다: " + request.cursor(), e);
+      }
       log.info("[FIND_ALL_NOTIFICATION] 다음 페이지 조회 userId={}, after={}", userId, request.after());
       results = notificationRepository
           .findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(
-              userId, request.after(), UUID.fromString(request.cursor()), pageable);
+              userId, request.after(), cursorId, pageable);
     }
 
     log.info("[FIND_ALL_NOTIFICATION] 조회 완료 userId={}, 조회된 개수={}", userId, results.size());
@@ -128,7 +137,10 @@ public class NotificationServiceImpl implements NotificationService {
         dtoList,
         normalizedLimit,
         totalElements,
-        dto -> dto.id().toString(),
+        dto -> dto.id().
+
+            toString(),
+
         NotificationDto::createdAt
     );
   }

--- a/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.team01.deokhugam.notification;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -191,12 +192,10 @@ public class NotificationServiceTest {
       mockUser = mock(User.class);
       given(mockUser.getId()).willReturn(UUID.randomUUID());
       mockReview = mock(Review.class);
-      given(mockReview.getId()).willReturn(UUID.randomUUID());
-      given(mockReview.getContent()).willReturn("테스트내용");
     }
 
     @Test
-    @DisplayName("알림 목록 조회 테스트 - 첫 페이지 성공")
+    @DisplayName("알림 목록 조회 테스트 성공 - 첫 페이지")
     void NotificationFindAllSuccess() {
       //given
       mockCursorPageRequest = new CursorPageRequest(null, null, 50);
@@ -209,6 +208,8 @@ public class NotificationServiceTest {
       OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
       given(notification.getCreatedAt()).willReturn(fixedTime);
       given(notification.getUpdatedAt()).willReturn(fixedTime);
+      given(mockReview.getId()).willReturn(UUID.randomUUID());
+      given(mockReview.getContent()).willReturn("테스트내용");
 
       given(notificationRepository.findByUserIdOrderByCreatedAtDesc(any(UUID.class), any(
           PageRequest.class)))
@@ -224,20 +225,21 @@ public class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("알림 목록 조회 테스트 - 다음 페이지 성공")
+    @DisplayName("알림 목록 조회 테스트 성공 - 다음 페이지")
     void NotificationFindAllSuccessNext() {
       //given
-      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-      mockCursorPageRequest = new CursorPageRequest(UUID.randomUUID().toString(), fixedTime, 50);
-
       Notification notification = mock(Notification.class);
       given(notification.getId()).willReturn(UUID.randomUUID());
       given(notification.getUser()).willReturn(mockUser);
       given(notification.getReview()).willReturn(mockReview);
       given(notification.getContent()).willReturn("알림 목록 조회 테스트");
       given(notification.isRead()).willReturn(false);
+      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+      mockCursorPageRequest = new CursorPageRequest(UUID.randomUUID().toString(), fixedTime, 50);
       given(notification.getCreatedAt()).willReturn(fixedTime);
       given(notification.getUpdatedAt()).willReturn(fixedTime);
+      given(mockReview.getId()).willReturn(UUID.randomUUID());
+      given(mockReview.getContent()).willReturn("테스트내용");
 
       given(notificationRepository.findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(
           any(UUID.class), any(OffsetDateTime.class), any(UUID.class), any(PageRequest.class)))
@@ -252,6 +254,102 @@ public class NotificationServiceTest {
       assertThat(result.content()).hasSize(1);
       assertThat(result.hasNext()).isFalse();
     }
+
+    @Test
+    @DisplayName("알림 목록 조회 테스트 실패 - after가 null이 아닌데 cursor가 null")
+    void NotificationFindAllTestFail1() {
+      //given
+      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+      mockCursorPageRequest = new CursorPageRequest(null, fixedTime, 50);
+      //when,then
+      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("after 가 지정된 경우 cursor 는 필수입니다.");
+
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 테스트 실패 - cursor이 잘못된 UUID 포맷인경우")
+    void NotificationFindAllTestFail2() {
+      //given
+      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+      mockCursorPageRequest = new CursorPageRequest("invalid-uuid", fixedTime, 50);
+      //when,then
+      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("cursor 형식이 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 테스트 성공 - hasNext = true 인 경우")
+    void NotificationFindAllTestHasNext(){
+      //given
+      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+      mockCursorPageRequest = new CursorPageRequest(null, null, 2);
+      Notification notification1 = mock(Notification.class);
+      Notification notification2 = mock(Notification.class);
+      Notification notification3 = mock(Notification.class);
+
+      List<Notification> testResult = List.of(notification1, notification2, notification3);
+
+      for (Notification n : testResult) {
+        given(n.getId()).willReturn(UUID.randomUUID());
+        given(n.getUser()).willReturn(mockUser);
+        given(n.getReview()).willReturn(mockReview);
+        given(n.getContent()).willReturn("알림 내용");
+        given(n.isRead()).willReturn(false);
+        given(n.getCreatedAt()).willReturn(fixedTime);
+        given(n.getUpdatedAt()).willReturn(fixedTime);
+        given(mockReview.getId()).willReturn(UUID.randomUUID());
+        given(mockReview.getContent()).willReturn("테스트내용");
+      }
+
+      given(notificationRepository.findByUserIdOrderByCreatedAtDesc(any(UUID.class), any(
+          PageRequest.class)))
+          .willReturn(testResult);
+
+      given(notificationRepository.countByUserId(any(UUID.class))).willReturn(3L);
+
+      //when
+      CursorPageResponse<NotificationDto> result = notificationService.findAll(mockUser.getId(),
+          mockCursorPageRequest);
+      //then
+      assertThat(result.content()).hasSize(2);
+      assertThat(result.hasNext()).isTrue();
+
+
+    }
+
+    @Test
+    @DisplayName("알림 조회 테스트 성공 - limit가 null인 경우")
+    void NotificationFindAllLimitNull(){
+      //given
+      mockCursorPageRequest = new CursorPageRequest(null, null, null);
+      Notification notification = mock(Notification.class);
+      given(notification.getId()).willReturn(UUID.randomUUID());
+      given(notification.getUser()).willReturn(mockUser);
+      given(notification.getReview()).willReturn(mockReview);
+      given(notification.getContent()).willReturn("알림 목록 조회 테스트");
+      given(notification.isRead()).willReturn(false);
+      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+      given(notification.getCreatedAt()).willReturn(fixedTime);
+      given(notification.getUpdatedAt()).willReturn(fixedTime);
+      given(mockReview.getId()).willReturn(UUID.randomUUID());
+      given(mockReview.getContent()).willReturn("테스트내용");
+
+      given(notificationRepository.findByUserIdOrderByCreatedAtDesc(any(UUID.class), any(
+          PageRequest.class)))
+          .willReturn(List.of(notification));
+      given(notificationRepository.countByUserId(any(UUID.class))).willReturn(1L);
+      //when
+      CursorPageResponse<NotificationDto> result = notificationService.findAll(mockUser.getId(),
+          mockCursorPageRequest);
+      //then
+      assertThat(result.content()).hasSize(1);
+      assertThat(result.hasNext()).isFalse();
+
+    }
+
 
   }
 

--- a/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
@@ -1,0 +1,258 @@
+package com.team01.deokhugam.notification;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import com.team01.deokhugam.global.pagination.CursorPageRequest;
+import com.team01.deokhugam.global.pagination.CursorPageResponse;
+import com.team01.deokhugam.notification.dto.NotificationCreateRequest;
+import com.team01.deokhugam.notification.dto.NotificationDto;
+import com.team01.deokhugam.notification.entity.Notification;
+import com.team01.deokhugam.notification.repository.NotificationRepository;
+import com.team01.deokhugam.notification.service.NotificationServiceImpl;
+import com.team01.deokhugam.review.entity.Review;
+import com.team01.deokhugam.user.entity.User;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceTest {
+
+  @InjectMocks
+  private NotificationServiceImpl notificationService;
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @Nested
+  @DisplayName("알림 생성 테스트")
+  class NotificationCreateTest {
+
+    private User mockReviewOwner;
+
+    @BeforeEach
+    void setup() {
+      mockReviewOwner = mock(User.class);
+      given(mockReviewOwner.getId()).willReturn(UUID.randomUUID());
+    }
+
+    @Test
+    @DisplayName("알림 생성 테스트 성공")
+    void NotificationCreateSuccess() {
+      //given
+      User actor = mock(User.class);
+      given(actor.getId()).willReturn(UUID.randomUUID());
+
+      Review review = mock(Review.class);
+      given(review.getUser()).willReturn(mockReviewOwner);
+
+      NotificationCreateRequest request = new NotificationCreateRequest(review, actor,
+          "테스트 내용");
+      //when
+      notificationService.create(request);
+      //then
+      then(notificationRepository).should().save(any(Notification.class));
+
+    }
+
+    @Test
+    @DisplayName("알림 생성 테스트 실패")
+    void NotificationCreateFail() {
+      //given
+      User actor = mockReviewOwner;
+
+      Review review = mock(Review.class);
+      given(review.getUser()).willReturn(mockReviewOwner);
+
+      NotificationCreateRequest request = new NotificationCreateRequest(review, actor,
+          "테스트 내용");
+      //when
+      notificationService.create(request);
+
+      //then
+      then(notificationRepository).should(never()).save(any(Notification.class));
+
+    }
+
+  }
+
+  @Nested
+  @DisplayName("알림 상태 수정 테스트")
+  class NotificationConfirmTest {
+
+    @Test
+    @DisplayName("알림 상태 수정 테스트 성공")
+    void NotificationConfirmSuccess() {
+      //given
+      Notification notification = mock(Notification.class);
+      given(notification.isRead()).willReturn(false);
+      //when
+      notificationService.confirm(notification);
+      //then
+      then(notification).should().markAsRead();
+
+    }
+
+    @Test
+    @DisplayName("알림 상태 수정 테스트 실패")
+    void NotificationConfirmFail() {
+      //given
+      Notification notification = mock(Notification.class);
+      given(notification.isRead()).willReturn(true);
+      //when
+      notificationService.confirm(notification);
+      //then
+      then(notification).should(never()).markAsRead();
+
+    }
+  }
+
+  @Nested
+  @DisplayName("알림 상태 전체 수정 테스트")
+  class NotificationConfirmAllTest {
+
+    private User mockUser;
+
+    @BeforeEach
+    void setup() {
+      mockUser = mock(User.class);
+      given(mockUser.getId()).willReturn(UUID.randomUUID());
+    }
+
+    @Test
+    @DisplayName("알림 상태 전체 수정 테스트 성공")
+    void NotificationConfirmAllSuccess() {
+      //given
+      Notification notification1 = mock(Notification.class);
+      Notification notification2 = mock(Notification.class);
+      given(notificationRepository.findAllByUserIdAndIsReadFalse(mockUser.getId()))
+          .willReturn(List.of(notification1, notification2));
+      //when
+      notificationService.confirmAll(mockUser);
+      //then
+      then(notification1).should().markAsRead();
+      then(notification2).should().markAsRead();
+    }
+
+    @Test
+    @DisplayName("알림 상태 수정 테스트 - 리스트가 비었을 경우")
+    void NotificationConfirmEmptyList() {
+      //given
+      given(notificationRepository.findAllByUserIdAndIsReadFalse(mockUser.getId()))
+          .willReturn(List.of());
+      //when
+      notificationService.confirmAll(mockUser);
+      //then
+      then(notificationRepository).should(never()).saveAll(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("알림 삭제 테스트")
+  class NotificationCleanupRead {
+
+    @Test
+    @DisplayName("알림 삭제 테스트 성공")
+    void NotificationCleanupReadSuccess() {
+      //given
+      //when
+      notificationService.cleanupReadNotifications();
+      //then
+      then(notificationRepository).should()
+          .deleteAllByIsReadTrueAndUpdatedAtBefore(any(OffsetDateTime.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("알림 목록 조회 테스트")
+  class NotificationFindAllTest {
+
+    private User mockUser;
+    private Review mockReview;
+    private CursorPageRequest mockCursorPageRequest;
+
+    @BeforeEach
+    void setup() {
+      mockUser = mock(User.class);
+      given(mockUser.getId()).willReturn(UUID.randomUUID());
+      mockReview = mock(Review.class);
+      given(mockReview.getId()).willReturn(UUID.randomUUID());
+      given(mockReview.getContent()).willReturn("테스트내용");
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 테스트 - 첫 페이지 성공")
+    void NotificationFindAllSuccess() {
+      //given
+      mockCursorPageRequest = new CursorPageRequest(null, null, 50);
+      Notification notification = mock(Notification.class);
+      given(notification.getId()).willReturn(UUID.randomUUID());
+      given(notification.getUser()).willReturn(mockUser);
+      given(notification.getReview()).willReturn(mockReview);
+      given(notification.getContent()).willReturn("알림 목록 조회 테스트");
+      given(notification.isRead()).willReturn(false);
+      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+      given(notification.getCreatedAt()).willReturn(fixedTime);
+      given(notification.getUpdatedAt()).willReturn(fixedTime);
+
+      given(notificationRepository.findByUserIdOrderByCreatedAtDesc(any(UUID.class), any(
+          PageRequest.class)))
+          .willReturn(List.of(notification));
+      given(notificationRepository.countByUserId(any(UUID.class))).willReturn(1L);
+      //when
+      CursorPageResponse<NotificationDto> result = notificationService.findAll(mockUser.getId(),
+          mockCursorPageRequest);
+      //then
+      assertThat(result.content()).hasSize(1);
+      assertThat(result.hasNext()).isFalse();
+
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 테스트 - 다음 페이지 성공")
+    void NotificationFindAllSuccessNext() {
+      //given
+      OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+      mockCursorPageRequest = new CursorPageRequest(UUID.randomUUID().toString(), fixedTime, 50);
+
+      Notification notification = mock(Notification.class);
+      given(notification.getId()).willReturn(UUID.randomUUID());
+      given(notification.getUser()).willReturn(mockUser);
+      given(notification.getReview()).willReturn(mockReview);
+      given(notification.getContent()).willReturn("알림 목록 조회 테스트");
+      given(notification.isRead()).willReturn(false);
+      given(notification.getCreatedAt()).willReturn(fixedTime);
+      given(notification.getUpdatedAt()).willReturn(fixedTime);
+
+      given(notificationRepository.findByUserIdAndCreatedAtBeforeOrderByCreatedAtDesc(
+          any(UUID.class), any(OffsetDateTime.class), any(UUID.class), any(PageRequest.class)))
+          .willReturn(List.of(notification));
+      given(notificationRepository.countByUserId(any(UUID.class))).willReturn(1L);
+
+      //when
+      CursorPageResponse<NotificationDto> result = notificationService.findAll(mockUser.getId(),
+          mockCursorPageRequest);
+
+      //then
+      assertThat(result.content()).hasSize(1);
+      assertThat(result.hasNext()).isFalse();
+    }
+
+  }
+
+}

--- a/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
@@ -281,6 +281,18 @@ public class NotificationServiceTest {
     }
 
     @Test
+    @DisplayName("알림 목록 조회 테스트 실패 - after이 null이고 cursor이 null이 아닌경우")
+    void NotificationFindAllTestFail3(){
+      //given
+      mockCursorPageRequest = new CursorPageRequest(UUID.randomUUID().toString(), null, 50);
+      //when,then
+      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("cursor 가 지정된 경우 after 도 필수입니다");
+
+    }
+
+    @Test
     @DisplayName("알림 목록 조회 테스트 성공 - hasNext = true 인 경우")
     void NotificationFindAllTestHasNext(){
       //given


### PR DESCRIPTION
## 📌 관련 이슈

- closes #81 

## 📝 작업 내용

- 알림 관리 조회 메서드를 추가하였고 그에 따라 필요한 레포지토리를 수정했습니다

## 💡 변경 사항

- 변경사항 1

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 알림 목록에 커서 기반 페이징 도입으로 스크롤/페이지네이션이 더 매끄러움
  * 관련 엔티티를 함께 조회하여 알림 로딩 성능 향상
  * 사용자별 알림 총수 계산 추가로 정확한 페이지 정보 제공
  * 생성시간(커서) 기반 필터링으로 이전/다음 페이지 탐색 개선

* **버그 수정**
  * 알림 목록 조회에서 빈값 반환 문제 수정

* **테스트**
  * 생성·확인·일괄확인·정리·커서 조회 흐름에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->