### PR TITLE
fix: Codecov 자동 커버리지 목표 설정 해제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,14 +78,13 @@ test {
 
 // 커버리지 집계에서 제외할 클래스 목록
 def excludes = [
-        '**/entity/**',                   // JPA 엔티티 (Lombok이 생성한 getter/setter만 존재)
-        '**/dto/**',                      // 데이터 전송 객체 (로직 없이 필드만 보유)
-        '**/mapper/**',                   // MapStruct가 빌드 타임에 자동 생성한 구현체
+        '**/entity/**',
+        '**/dto/**',
+        '**/mapper/**',
         '**/enums/**',
-        // → 개발자가 작성한 코드가 아니므로 테스트 대상 아님
-        '**/config/**',                   // Spring Config 클래스 (프레임워크가 실행하며 검증)
-        '**/exception/**',                // 커스텀 예외 클래스 (단순 상속/생성자만 존재)
-        '**/Q*.class'                     // QueryDSL이 자동 생성하는 Q 클래스
+        '**/config/**',
+        '**/exception/**',
+        '**/Q*.class'
 ]
 
 // JaCoCo 커버리지 리포트 생성 태스크 설정

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    # 프로젝트 전체 커버리지 기준 체크
+    project:
+      default:
+        informational: true
+    # 이번 PR에서 변경된 라인(diff)의 커버리지 기준 체크
+    patch:
+      default:
+        # 커버리지가 기준 미달이어도 상태를 success로 보고
+        informational: true

--- a/src/main/java/com/team01/deokhugam/DeokhugamApplication.java
+++ b/src/main/java/com/team01/deokhugam/DeokhugamApplication.java
@@ -1,9 +1,17 @@
 package com.team01.deokhugam;
 
+import com.team01.deokhugam.user.config.UserCleanupProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+// Spring의 스케줄링 기능을 활성화 - @Scheduled가 붙은 메서드가 동작하기 위해 필수
+@EnableScheduling
+// 외부 설정 파일의 값을 자바 객체로 바인딩하는 기능 활성화
+// UserCleanUpProperties 클래스를 Spring Bean으로 등록
+@EnableConfigurationProperties(UserCleanupProperties.class)
 public class DeokhugamApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/team01/deokhugam/user/config/UserCleanupProperties.java
+++ b/src/main/java/com/team01/deokhugam/user/config/UserCleanupProperties.java
@@ -1,0 +1,17 @@
+package com.team01.deokhugam.user.config;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+// 설정값을 외부 설정 파일에서 읽어와 자바 객체로 바인딩
+// 설정값은 런타임에 바뀌면 안됨 -> 불변성 보장을 위한 record 사용
+// record -> 테스트에서 값 바꾸기 객체 주입으로 용이
+@Validated
+@ConfigurationProperties(prefix = "deokhugam.user.cleanup")
+public record UserCleanupProperties(
+    // 논리 삭제된 사용자를 물리 삭제하기까지의 보존 시간
+    @Min(1) long retentionMinutes // 음수 방지 검증 (프로필 설정 실수 방지)
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/team01/deokhugam/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.team01.deokhugam.user.repository;
 
 import com.team01.deokhugam.user.entity.User;
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +29,11 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   WHERE u.id = :id AND u.deleted_at IS NULL
    */
   Optional<User> findByIdAndDeletedAtIsNull(UUID id);
+
+  /*
+  SELECT u
+  FROM User u
+  WHERE u.is_deleted = true AND u.deleted_at < :expiredBefore
+   */
+  List<User> findAllByIsDeletedTrueAndDeletedAtBefore(OffsetDateTime expiredBefore);
 }

--- a/src/main/java/com/team01/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/team01/deokhugam/user/repository/UserRepository.java
@@ -12,28 +12,28 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   /*
   SELECT COUNT(*) > 0
   FROM users u
-  WHERE u.email = ? AND u.deleted_at IS NULL
+  WHERE u.email = ? AND u.deletedAt IS NULL
    */
   boolean existsByEmailAndDeletedAtIsNull(String email);
 
   /*
   SELECT u
   FROM User u
-  WHERE u.email = :email AND u.deleted_at IS NULL
+  WHERE u.email = :email AND u.deletedAt IS NULL
    */
   Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
   /*
   SELECT u
   FROM User u
-  WHERE u.id = :id AND u.deleted_at IS NULL
+  WHERE u.id = :id AND u.deletedAt IS NULL
    */
   Optional<User> findByIdAndDeletedAtIsNull(UUID id);
 
   /*
   SELECT u
   FROM User u
-  WHERE u.is_deleted = true AND u.deleted_at < :expiredBefore
+  WHERE u.isDeleted = true AND u.deletedAt < :expiredBefore
    */
   List<User> findAllByIsDeletedTrueAndDeletedAtBefore(OffsetDateTime expiredBefore);
 }

--- a/src/main/java/com/team01/deokhugam/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/team01/deokhugam/user/scheduler/UserCleanupScheduler.java
@@ -1,0 +1,60 @@
+package com.team01.deokhugam.user.scheduler;
+
+import com.team01.deokhugam.user.config.UserCleanupProperties;
+import com.team01.deokhugam.user.entity.User;
+import com.team01.deokhugam.user.repository.UserRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// TODO: Spring Batch로 리펙터링
+// 논리 삭제된 사용자를 보존 기간 경과 후 물리 삭제하는 스케줄러
+@Slf4j
+@Component
+public class UserCleanupScheduler {
+
+  private final UserRepository userRepository;
+  private final UserCleanupProperties userCleanupProperties;
+
+  public UserCleanupScheduler(
+      UserRepository userRepository,
+      UserCleanupProperties userCleanupProperties
+  ) {
+    this.userRepository = userRepository;
+    this.userCleanupProperties = userCleanupProperties;
+  }
+
+  /*
+   초 분 시 일 월 요일
+   0  0  3 *  *  *
+     * 모든 값
+     / 간격 지정
+     , 여러 값 나열
+   배포 환경에서는 매일 3시에 메서드 실행. 개발 환경에서는 1분마다 메서드 실행
+   */
+  // @Scheduled의 cron은 서버 JVM의 기본 타임존을 따른다. -> zone 명시 필요
+  @Scheduled(
+      cron = "${deokhugam.user.cleanup.cron}",
+      zone = "Asia/Seoul"
+  )
+  @Transactional
+  public void cleanupSoftDeletedUsers() {
+    /*
+    삭제 기준 시간(expiredBefore) = 현재시간 - 보존기간
+    예시) 현재 2025-04-19 14:00 -> expiredBefore 2025-04-18 14:00
+    */
+    OffsetDateTime expiredBefore
+        = OffsetDateTime.now().minusMinutes(userCleanupProperties.retentionMinutes());
+    // 전체 대상을 List로 한 번에 메모리에 올림. 데이터가 많을 경우 OOM 이슈 발생 가능 -> 추후 Spring Batch로 리팩터링
+    List<User> targets = userRepository.findAllByIsDeletedTrueAndDeletedAtBefore(expiredBefore);
+    if (targets.isEmpty()) {
+      return;
+    }
+    log.info("논리삭제 유저 물리 삭제 시작: count={}, expiredBefore={}", targets.size(), expiredBefore);
+    userRepository.deleteAll(targets);
+    log.info("논리삭제 유저 물리 삭제 완료: count={}", targets.size());
+  }
+}

--- a/src/main/java/com/team01/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/team01/deokhugam/user/service/UserService.java
@@ -97,6 +97,7 @@ public class UserService {
   @Transactional
   public void permanentDeleteUser(UUID userId) {
     log.warn("사용자 물리 삭제 시작: userId={}", userId);
+    // 물리 삭제는 이미 논리 삭제된 유저도 대상이므로 findById 사용
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
     userRepository.delete(user);

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -24,3 +24,11 @@ management:
   info:
     env:
       enabled: true
+
+deokhugam:
+  user:
+    cleanup:
+      # 개발 환경에서는 테스트 용이성을 위해 3분으로 설정
+      retention-minutes: 3
+      # 1분마다 cleanupSoftDeletedUsers 실행 (빠른 테스트용)
+      cron: "0 * * * * *"

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -23,3 +23,11 @@ management:
   info:
     env:
       enabled: false
+
+deokhugam:
+  user:
+    cleanup:
+      # 논리 삭제 후 1일 경과 뒤 유저 정보가 완전히 삭제
+      retention-minutes: 1440
+      # 매일 3시 (1회) - 사용자 이용 적은 시간대 - cron 간격 24h - 최대 지연 48h
+      cron: "0 0 3 * * *"

--- a/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/user/service/UserServiceTest.java
@@ -293,4 +293,38 @@ class UserServiceTest {
       verify(userRepository, never()).delete(any(User.class));
     }
   }
+
+  @Nested
+  @DisplayName("permanentDeleteUser - 사용자 물리 삭제")
+  class PermanentDeleteUser {
+
+    @Test
+    @DisplayName("사용자 물리 삭제 성공")
+    void permanentDeleteUser_Success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.findById(userId)).willReturn(Optional.of(savedUser));
+
+      // when
+      userService.permanentDeleteUser(userId);
+
+      // then
+      verify(userRepository).findById(userId);
+      verify(userRepository).delete(savedUser);
+    }
+
+    @Test
+    @DisplayName("사용자 물리 삭제 실패 - 존재하지 않는 사용자")
+    void permanentDeleteUser_Fail_UserNotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> userService.permanentDeleteUser(userId))
+          .isInstanceOf(UserNotFoundException.class);
+
+      verify(userRepository, never()).delete(any(User.class));
+    }
+  }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -20,6 +20,12 @@ deokhugam:
     type: local
     local:
       root-path: .deokhugam/storage-test
+  user:
+    cleanup:
+      # 개발 환경에서는 테스트 용이성을 위해 3분으로 설정
+      retention-minutes: 3
+      # 1분마다 cleanupSoftDeletedUsers 실행 (빠른 테스트용)
+      cron: "0 * * * * *"
 
 logging:
   level:


### PR DESCRIPTION
## 📌 관련 이슈

- closes #140 

## 📝 작업 내용

- Codecov에는 target: auto 라는 기본값이 존재. (codecov.yml 파일을 직접 만들지 않아도 적용되는 기본값)
- 이 PR의 diff 커버리지가 main의 전체 커버리지와 같거나 높아야 한다라는 규칙이 자동으로 설정되어 있었음
- 커버리지가 기준 미달이어도 상태를 success로 보고하도록 설정값 수정

## 💡 변경 사항

## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 소프트 삭제된 사용자 정보의 자동 정리 기능 추가: 설정된 보존 기간 경과 후 자동으로 삭제된 사용자 정보를 물리적으로 제거합니다. 개발 환경에서는 1분마다, 프로덕션에서는 매일 새벽 3시에 실행됩니다.

* **Chores**
  * 테스트 커버리지 체크 설정 추가: 코드 커버리지 검증을 비차단 모드로 설정하여 빌드 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->