### PR TITLE
feat: 리뷰 수정 기능 구현 #45

### DIFF
--- a/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 
   // review
   REVIEW_NOT_FOUND(404, "REVIEW_NOT_FOUND", "리뷰를 찾을 수 없습니다."),
+  REVIEW_UPDATE_FORBIDDEN(403, "REVIEW_UPDATE_FORBIDDEN", "리뷰를 수정할 권한이 없습니다."),
 
   // user
   EMAIL_ALREADY_EXISTS(409, "EMAIL_ALREADY_EXISTS", "이미 등록된 이메일입니다."),

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewUpdateForbidden.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewUpdateForbidden.java
@@ -1,0 +1,23 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class ReviewUpdateForbidden extends DeokhugamException {
+
+  public ReviewUpdateForbidden(UUID reviewId, UUID requestUserId) {
+    super(
+        ErrorCode.REVIEW_UPDATE_FORBIDDEN,
+        Map.of(
+            "requestUserId",
+            requestUserId.toString(),
+            "reviewId",
+            reviewId.toString(),
+            "rule",
+            "권한이 있는 사용자만 리뷰를 수정할 수 있음"
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/team01/deokhugam/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.team01.deokhugam.review.controller;
 
+import com.team01.deokhugam.global.constant.AuthHeader;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
@@ -60,7 +61,7 @@ public class ReviewController {
   @GetMapping("/{reviewId}")
   public ResponseEntity<ReviewDto> getReview(
       @PathVariable UUID reviewId,
-      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId
   ) {
     return ResponseEntity.ok(reviewService.getReview(reviewId, requestUserId));
   }
@@ -72,7 +73,7 @@ public class ReviewController {
   })
   @GetMapping
   public ResponseEntity<CursorPageResponseReviewDto> getReviews(
-      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId,
       @RequestParam(required = false) UUID userId,
       @RequestParam(required = false) UUID bookId,
       @RequestParam(required = false) String keyword,
@@ -106,7 +107,7 @@ public class ReviewController {
   @PatchMapping("/{reviewId}")
   public ResponseEntity<ReviewDto> updateReview(
       @PathVariable UUID reviewId,
-      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId,
       @Valid @RequestBody ReviewUpdateRequest request
   ) {
     ReviewDto response = reviewService.updateReview(reviewId, requestUserId, request);

--- a/src/main/java/com/team01/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/team01/deokhugam/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
+import com.team01.deokhugam.review.dto.ReviewUpdateRequest;
 import com.team01.deokhugam.review.service.ReviewService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -92,5 +94,22 @@ public class ReviewController {
             limit
         )
     );
+  }
+
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "리뷰 수정 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)"),
+      @ApiResponse(responseCode = "403", description = "리뷰 수정 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "리뷰 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @PatchMapping("/{reviewId}")
+  public ResponseEntity<ReviewDto> updateReview(
+      @PathVariable UUID reviewId,
+      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+      @Valid @RequestBody ReviewUpdateRequest request
+  ) {
+    ReviewDto response = reviewService.updateReview(reviewId, requestUserId, request);
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewService.java
@@ -4,6 +4,7 @@ import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
+import com.team01.deokhugam.review.dto.ReviewUpdateRequest;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -24,4 +25,6 @@ public interface ReviewService {
       OffsetDateTime after,
       Integer limit
   );
+
+  ReviewDto updateReview(UUID reviewId, UUID requestUserId, ReviewUpdateRequest request);
 }

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
@@ -10,6 +10,7 @@ import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
 import com.team01.deokhugam.review.dto.ReviewSearchCondition;
+import com.team01.deokhugam.review.dto.ReviewUpdateRequest;
 import com.team01.deokhugam.review.entity.Review;
 import com.team01.deokhugam.review.mapper.ReviewMapper;
 import com.team01.deokhugam.review.repository.ReviewRepository;
@@ -124,5 +125,23 @@ public class ReviewServiceImpl implements ReviewService {
         page.totalElements(),
         page.hasNext()
     );
+  }
+
+  @Override
+  public ReviewDto updateReview(UUID reviewId, UUID requestUserId, ReviewUpdateRequest request) {
+    
+    // 리뷰  존재 검증
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
+        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+    // 사용자가 쓴 리뷰인지 검증
+    if (!review.getUser().getId().equals(requestUserId)) {
+      throw new IllegalArgumentException("리뷰를 수정할 권한이 없습니다.");
+    }
+
+    // 리뷰 수정
+    review.update(request.content(), request.rating());
+
+    return reviewMapper.toDto(review);
   }
 }

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
@@ -4,6 +4,7 @@ import com.team01.deokhugam.book.entity.Book;
 import com.team01.deokhugam.book.repository.BookRepository;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.book.BookNotFoundException;
+import com.team01.deokhugam.global.exception.review.ReviewUpdateForbidden;
 import com.team01.deokhugam.global.pagination.CursorPageResponse;
 import com.team01.deokhugam.global.pagination.CursorPaginationUtils;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
@@ -128,15 +129,16 @@ public class ReviewServiceImpl implements ReviewService {
   }
 
   @Override
+  @Transactional
   public ReviewDto updateReview(UUID reviewId, UUID requestUserId, ReviewUpdateRequest request) {
-    
+
     // 리뷰  존재 검증
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
         .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
 
     // 사용자가 쓴 리뷰인지 검증
     if (!review.getUser().getId().equals(requestUserId)) {
-      throw new IllegalArgumentException("리뷰를 수정할 권한이 없습니다.");
+      throw new ReviewUpdateForbidden(reviewId, requestUserId);
     }
 
     // 리뷰 수정

--- a/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +14,7 @@ import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
+import com.team01.deokhugam.review.dto.ReviewUpdateRequest;
 import com.team01.deokhugam.review.service.ReviewService;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -21,8 +23,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ReviewController.class)
@@ -35,7 +37,7 @@ class ReviewControllerTest {
   @Autowired
   private ObjectMapper objectMapper;
 
-  @MockBean
+  @MockitoBean
   private ReviewService reviewService;
 
   @Test
@@ -207,5 +209,44 @@ class ReviewControllerTest {
     mockMvc.perform(get("/api/reviews")
             .param("keyword", "테스트"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 - 성공")
+  void updateReview_success() throws Exception {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+    UUID bookId = UUID.randomUUID();
+
+    ReviewUpdateRequest request = new ReviewUpdateRequest("수정된 리뷰", 4.5);
+
+    ReviewDto response = new ReviewDto(
+        reviewId,
+        bookId,
+        "테스트 책",
+        "thumb.jpg",
+        requestUserId,
+        "테스트 유저",
+        "수정된 리뷰",
+        4.5,
+        0,
+        0,
+        false,
+        OffsetDateTime.parse("2026-04-22T10:00:00+09:00"),
+        OffsetDateTime.parse("2026-04-22T11:00:00+09:00")
+    );
+
+    given(reviewService.updateReview(reviewId, requestUserId, request)).willReturn(response);
+
+    // when & then
+    mockMvc.perform(patch("/api/reviews/{reviewId}", reviewId)
+            .header("Deokhugam-Request-User-ID", requestUserId)
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(reviewId.toString()))
+        .andExpect(jsonPath("$.content").value("수정된 리뷰"))
+        .andExpect(jsonPath("$.rating").value(4.5));
   }
 }

--- a/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team01.deokhugam.global.enums.SortDirection;
+import com.team01.deokhugam.global.exception.review.ReviewUpdateForbidden;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
@@ -248,5 +249,25 @@ class ReviewControllerTest {
         .andExpect(jsonPath("$.id").value(reviewId.toString()))
         .andExpect(jsonPath("$.content").value("수정된 리뷰"))
         .andExpect(jsonPath("$.rating").value(4.5));
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 - 권한 없는 사용자면 403 반환")
+  void updateReview_fail_whenForbidden() throws Exception {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    ReviewUpdateRequest request = new ReviewUpdateRequest("수정 시도", 4.5);
+
+    given(reviewService.updateReview(reviewId, requestUserId, request))
+        .willThrow(new ReviewUpdateForbidden(reviewId, requestUserId));
+
+    // when & then
+    mockMvc.perform(patch("/api/reviews/{reviewId}", reviewId)
+            .header("Deokhugam-Request-User-ID", requestUserId)
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
   }
 }

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -1,16 +1,22 @@
 package com.team01.deokhugam.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.team01.deokhugam.book.entity.Book;
 import com.team01.deokhugam.book.repository.BookRepository;
 import com.team01.deokhugam.global.enums.SortDirection;
+import com.team01.deokhugam.global.exception.ErrorCode;
 import com.team01.deokhugam.global.exception.book.BookNotFoundException;
+import com.team01.deokhugam.global.exception.review.ReviewUpdateForbidden;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
@@ -340,5 +346,30 @@ class ReviewServiceImplTest {
     verify(review).update("수정된 리뷰", 4.5);
     assertThat(result.content()).isEqualTo("수정된 리뷰");
     assertThat(result.rating()).isEqualTo(4.5);
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 - 권한 없는 사용자가 수정 시 예외 발생")
+  void updateReview_fail_whenRequesterIsNotAuthor() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID authorId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    User author = mock(User.class);
+    Review review = mock(Review.class);
+    ReviewUpdateRequest request = new ReviewUpdateRequest("수정 시도", 4.5);
+
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
+    given(review.getUser()).willReturn(author);
+    given(author.getId()).willReturn(authorId);
+
+    // when & then
+    assertThatThrownBy(() -> reviewServiceImpl.updateReview(reviewId, requestUserId, request))
+        .isInstanceOf(ReviewUpdateForbidden.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_UPDATE_FORBIDDEN);
+
+    verify(review, never()).update(anyString(), anyDouble());
   }
 }

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.team01.deokhugam.book.entity.Book;
 import com.team01.deokhugam.book.repository.BookRepository;
@@ -13,6 +15,7 @@ import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
 import com.team01.deokhugam.review.dto.ReviewSearchCondition;
+import com.team01.deokhugam.review.dto.ReviewUpdateRequest;
 import com.team01.deokhugam.review.entity.Review;
 import com.team01.deokhugam.review.mapper.ReviewMapper;
 import com.team01.deokhugam.review.repository.ReviewRepository;
@@ -70,9 +73,9 @@ class ReviewServiceImplTest {
         new ReviewCreateRequest(bookId, userId, "테스트 리뷰", 4.5);
 
     // Book/User 내부 필드는 안 쓰므로 mock 객체로 대체
-    Book book = org.mockito.Mockito.mock(Book.class);
-    User user = org.mockito.Mockito.mock(User.class);
-    Review savedReview = org.mockito.Mockito.mock(Review.class);
+    Book book = mock(Book.class);
+    User user = mock(User.class);
+    Review savedReview = mock(Review.class);
 
     // 서비스가 최종적으로 반환할 DTO
     ReviewDto reviewDto = new ReviewDto(
@@ -128,7 +131,7 @@ class ReviewServiceImplTest {
         new ReviewCreateRequest(bookId, userId, "테스트 리뷰", 4.5);
 
     // 도서는 존재
-    Book book = org.mockito.Mockito.mock(Book.class);
+    Book book = mock(Book.class);
     given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
 
     // 유저는 존재하지 않음
@@ -151,8 +154,8 @@ class ReviewServiceImplTest {
     ReviewCreateRequest reviewCreateRequest =
         new ReviewCreateRequest(bookId, userId, "테스트 리뷰", 4.5);
 
-    Book book = org.mockito.Mockito.mock(Book.class);
-    User user = org.mockito.Mockito.mock(User.class);
+    Book book = mock(Book.class);
+    User user = mock(User.class);
 
     // 도서/유저는 존재
     given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
@@ -176,7 +179,7 @@ class ReviewServiceImplTest {
   @DisplayName("리뷰 상세 조회 - 성공")
   void getReview_success() {
     // given
-    Review review = org.mockito.Mockito.mock(Review.class);
+    Review review = mock(Review.class);
 
     ReviewDto reviewDto = new ReviewDto(
         reviewId, bookId, "테스트 책", "thumb.jpg", userId, "tester",
@@ -216,7 +219,7 @@ class ReviewServiceImplTest {
   @DisplayName("리뷰 목록 조회 - 성공")
   void searchReviews_success() {
     // given
-    Review review = org.mockito.Mockito.mock(Review.class);
+    Review review = mock(Review.class);
 
     ReviewDto reviewDto = new ReviewDto(
         reviewId, bookId, "테스트 책", "thumb.jpg", userId, "tester",
@@ -297,5 +300,45 @@ class ReviewServiceImplTest {
 
     // then
     assertThat(exception.getMessage()).isEqualTo("orderBy는 createdAt 또는 rating만 가능합니다.");
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 - 성공")
+  void updateReview_success() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    User user = mock(User.class);
+    Review review = mock(Review.class);
+    ReviewUpdateRequest request = new ReviewUpdateRequest("수정된 리뷰", 4.5);
+    ReviewDto reviewDto = new ReviewDto(
+        reviewId,
+        UUID.randomUUID(),
+        "테스트 책",
+        "thumb.jpg",
+        requestUserId,
+        "테스트 유저",
+        "수정된 리뷰",
+        4.5,
+        0,
+        0,
+        false,
+        OffsetDateTime.now(),
+        OffsetDateTime.now()
+    );
+
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
+    given(review.getUser()).willReturn(user);
+    given(user.getId()).willReturn(requestUserId);
+    given(reviewMapper.toDto(review)).willReturn(reviewDto);
+
+    // when
+    ReviewDto result = reviewServiceImpl.updateReview(reviewId, requestUserId, request);
+
+    // then
+    verify(review).update("수정된 리뷰", 4.5);
+    assertThat(result.content()).isEqualTo("수정된 리뷰");
+    assertThat(result.rating()).isEqualTo(4.5);
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #45 

## 📝 작업 내용

- 리뷰 수정 기능 구현
- 리뷰 작성자 본인 검증 추가
- 리뷰 수정 API 추가
- 수정 기능 서비스/컨트롤러 테스트 작성

## 💡 변경 사항

- PATCH /api/reviews/{reviewId} 추가
- ReviewUpdateRequest 기반 content, rating 수정 처리
- 수정 성공 시 ReviewDto 반환
- @MockBean -> @MokitoBean으로 변경

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리뷰 업데이트 기능 추가 — PATCH로 리뷰 내용과 평점 수정 가능
  * 요청자 ID 기반 헤더 검증으로 작성자만 수정 허용 및 권한 에러 처리(403)

* **Tests**
  * 컨트롤러 및 서비스 계층에 성공/권한 실패 시나리오를 포함한 단위/통합 테스트 추가

* **Chores**
  * 권한 관련 오류 코드 및 전용 예외 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->