### PR TITLE
feat: CI 워크플로우에 push 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
       - synchronize      # PR에 새 커밋이 푸시됐을 때
       - reopened         # 닫혔던 PR이 다시 열릴 때
       - ready_for_review # Draft PR이 Ready로 바뀔 때
+  push:
+    branches: [ dev, main ] # 머지 후 dev/main 기준 CI 및 Codecov 갱신용
 
 # 권한 설정: 이 워크플로우가 가진 GitHub 토큰의 권한 범위
 permissions:


### PR DESCRIPTION
## 📌 관련 이슈

- closes #167 

## 📝 작업 내용

- PR 머지 후 dev/main 브랜치가 실제로 갱신될 때도 CI 실행
- pull_request는 PR 브랜치 기준 검사만 수행하므로
- 머지된 최종 브랜치 기준 coverage/codecov 갱신을 위해 push도 필요

## 💡 변경 사항

- 변경사항 1

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 (Chores)**
  * CI/CD 워크플로우가 업데이트되었습니다. 개발 및 메인 브랜치로의 푸시 시에도 자동화된 테스트가 실행되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->