### PR TITLE
feat: 썸네일 이미지 저장 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,15 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     // JUnit Platform Launcher
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // AWS SDK v2 BOM
+    implementation platform('software.amazon.awssdk:bom:2.42.33')
+
+    // S3와의 통신을 위한 AWS SDK v2 라이브러리
+    implementation 'software.amazon.awssdk:s3'
+
+    // AWS 인증 처리 모듈
+    implementation 'software.amazon.awssdk:auth'
 }
 
 // *-plain.jar 생성되지 않도록 설정

--- a/src/main/java/com/team01/deokhugam/book/BookMapper.java
+++ b/src/main/java/com/team01/deokhugam/book/BookMapper.java
@@ -2,9 +2,12 @@ package com.team01.deokhugam.book;
 
 import com.team01.deokhugam.book.dto.BookDto;
 import com.team01.deokhugam.book.entity.Book;
+import com.team01.deokhugam.book.storage.ThumbnailStorage;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {ThumbnailStorage.class})
 public interface BookMapper {
+  @Mapping(source = "thumbnailUrl", target = "thumbnailUrl", qualifiedByName = "toPresignedUrl")
   BookDto toDto(Book book);
 }

--- a/src/main/java/com/team01/deokhugam/book/entity/Book.java
+++ b/src/main/java/com/team01/deokhugam/book/entity/Book.java
@@ -78,4 +78,8 @@ public class Book extends BaseRemovableEntity {
   public void updatePublishedDate(LocalDate newPublishedDate){
     this.publishedDate = newPublishedDate;
   }
+
+  public void updateThumbnailUrl(String newUrl) {
+    this.thumbnailUrl = newUrl;
+  }
 }

--- a/src/main/java/com/team01/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/team01/deokhugam/book/service/BookService.java
@@ -10,12 +10,14 @@ import com.team01.deokhugam.book.dto.naver.NaverBookResponse;
 import com.team01.deokhugam.book.dto.naver.NaverBookResponse.NaverBookItem;
 import com.team01.deokhugam.book.entity.Book;
 import com.team01.deokhugam.book.repository.BookRepository;
+import com.team01.deokhugam.book.storage.ThumbnailStorage;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.book.BookNotFoundException;
 import com.team01.deokhugam.global.exception.book.DuplicatedIsbnException;
 import com.team01.deokhugam.global.pagination.CursorPageResponse;
 import com.team01.deokhugam.global.pagination.CursorPaginationUtils;
 import com.team01.deokhugam.global.pagination.PageLimitPolicy;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -47,6 +49,7 @@ public class BookService {
   private final RestClient naverRestClient;
   private final RestClient defaultRestClient;
   private final RestClient ocrRestClient;
+  private final ThumbnailStorage thumbnailStorage;
 
   // isbn패턴 정규표현식: 978 혹은 979로 시작해서 (-)와 숫자가 조합되서 나오는 10자리~20자리의 문자열
   private static final Pattern ISBN_PATTERN = Pattern.compile("97[89][0-9\\s-]{10,20}");
@@ -57,12 +60,14 @@ public class BookService {
       BookRepository bookRepository,
       @Qualifier("naverRestClient") RestClient naverRestClient,
       @Qualifier("defaultRestClient") RestClient defaultRestClient,
-      @Qualifier("ocrRestClient") RestClient ocrRestClient) {
+      @Qualifier("ocrRestClient") RestClient ocrRestClient,
+      ThumbnailStorage thumbnailStorage) {
     this.bookMapper = bookMapper;
     this.bookRepository = bookRepository;
     this.naverRestClient = naverRestClient;
     this.defaultRestClient = defaultRestClient;
     this.ocrRestClient = ocrRestClient;
+    this.thumbnailStorage = thumbnailStorage;
   }
 
   @Transactional
@@ -85,7 +90,12 @@ public class BookService {
         build();
     // 썸네일 저장
     if (thumbnail != null && !thumbnail.isEmpty()) {
-      // 추후 s3로 업로드, presignURL 가져오는 로직 추가
+      try {
+        String s3Url = thumbnailStorage.upload(thumbnail);
+        book.addThumbnail(s3Url);
+      } catch (IOException e){
+        throw new RuntimeException("파일 업로드중 문제가 발생했습니다");
+      }
     }
     // 만약 두 사용자가 동시에 같은 isbn으로 등록시 둘다 중복 검사에서는 통과하지만 등록시에는 uinque제약 조건으로
     // DataIntegrityViolationException가 발생하기 때문에 해당 예외 발생시 커스텀 예외로 응답하도록 함
@@ -145,7 +155,7 @@ public class BookService {
   }
 
   @Transactional
-  public BookDto updateBook(BookUpdateRequest request, UUID bookId, MultipartFile thumbnailImage){
+  public BookDto updateBook(BookUpdateRequest request, UUID bookId, MultipartFile thumbnailImage) {
     Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
         .orElseThrow(() -> new BookNotFoundException(bookId));
 
@@ -165,7 +175,17 @@ public class BookService {
       book.updatePublishedDate(request.getPublishedDate());
     }
     if(thumbnailImage != null && !thumbnailImage.isEmpty()){
-      // 추후 s3로 업로드, presignURL 가져오는 로직 추가
+      if(book.getThumbnailUrl() != null){
+        thumbnailStorage.delete(book.getThumbnailUrl());
+      }
+
+      try {
+        String s3Url = thumbnailStorage.upload(thumbnailImage);
+        book.updateThumbnailUrl(s3Url);
+      } catch (IOException e){
+        throw new RuntimeException("파일 업로드중 오류가 발생했습니다",e);
+      }
+
     }
 
     return bookMapper.toDto(book);

--- a/src/main/java/com/team01/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/team01/deokhugam/book/service/BookService.java
@@ -34,6 +34,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
@@ -175,17 +177,39 @@ public class BookService {
       book.updatePublishedDate(request.getPublishedDate());
     }
     if(thumbnailImage != null && !thumbnailImage.isEmpty()){
-      if(book.getThumbnailUrl() != null){
-        thumbnailStorage.delete(book.getThumbnailUrl());
-      }
+      String oldThumbnailUrl = book.getThumbnailUrl();
+      String newS3Url;
 
       try {
-        String s3Url = thumbnailStorage.upload(thumbnailImage);
-        book.updateThumbnailUrl(s3Url);
+        newS3Url = thumbnailStorage.upload(thumbnailImage);
+        book.updateThumbnailUrl(newS3Url);
       } catch (IOException e){
         throw new RuntimeException("파일 업로드중 오류가 발생했습니다",e);
       }
+      // 트랜잭션 롤백시 s3의 데이터 유실 문제 해결
+      // 만약 s3의 원래 이미지를 삭제하고 새로운 이미지를 넣고 난 뒤에 트랜잭션이 롤백되면 db는 제대로 롤백되지만
+      // s3는 데이터가 롤백되지 않는 문제가 있음
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        // 트랜잭션이 커밋된다면
+        @Override
+        public void afterCommit() {
+          if (oldThumbnailUrl != null) {
+            // 원래 데이터 삭제 진행
+            thumbnailStorage.delete(oldThumbnailUrl);
+          }
+        }
 
+        // 트랜직션이 커밋되는 롤백되는 상관없이 완료가 되면
+        @Override
+        public void afterCompletion(int status) {
+          // 만약 롤백으로 완료되면
+          if (status == STATUS_ROLLED_BACK)
+            {
+              // 새로운 이미지를 삭제함
+              thumbnailStorage.delete(newS3Url);
+            }
+        }
+      });
     }
 
     return bookMapper.toDto(book);
@@ -203,6 +227,11 @@ public class BookService {
   public void permanentDeleteBook(UUID bookId){
     Book book = bookRepository.findByIdAndIsDeletedTrue(bookId)
         .orElseThrow(() -> new BookNotFoundException(bookId));
+
+    // 완전 db에서도 삭제되면 저장소의 썸네일도 삭제
+    if (book.getThumbnailUrl() != null) {
+      thumbnailStorage.delete(book.getThumbnailUrl());
+    }
 
     bookRepository.delete(book);
   }

--- a/src/main/java/com/team01/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/team01/deokhugam/book/service/BookService.java
@@ -92,12 +92,27 @@ public class BookService {
         build();
     // 썸네일 저장
     if (thumbnail != null && !thumbnail.isEmpty()) {
+      String s3Url;
       try {
-        String s3Url = thumbnailStorage.upload(thumbnail);
+        s3Url = thumbnailStorage.upload(thumbnail);
         book.addThumbnail(s3Url);
       } catch (IOException e){
-        throw new RuntimeException("파일 업로드중 문제가 발생했습니다");
+        throw new RuntimeException("파일 업로드중 문제가 발생했습니다",e);
       }
+
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        // 트랜직션이 커밋되는 롤백되는 상관없이 완료가 되면
+        @Override
+        public void afterCompletion(int status) {
+          // 만약 롤백으로 완료되면
+          if (status == STATUS_ROLLED_BACK)
+          {
+            // 새로운 이미지를 삭제함
+            thumbnailStorage.delete(s3Url);
+          }
+        }
+      });
+
     }
     // 만약 두 사용자가 동시에 같은 isbn으로 등록시 둘다 중복 검사에서는 통과하지만 등록시에는 uinque제약 조건으로
     // DataIntegrityViolationException가 발생하기 때문에 해당 예외 발생시 커스텀 예외로 응답하도록 함

--- a/src/main/java/com/team01/deokhugam/book/storage/LocalThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/LocalThumbnailStorage.java
@@ -18,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Component
 public class LocalThumbnailStorage implements ThumbnailStorage {
 
-  @Value("${deokhugam.storage.local.root-path")
+  @Value("${deokhugam.storage.local.root-path}")
   private String uploadDir;
 
   @PostConstruct

--- a/src/main/java/com/team01/deokhugam/book/storage/LocalThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/LocalThumbnailStorage.java
@@ -1,0 +1,66 @@
+package com.team01.deokhugam.book.storage;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@ConditionalOnProperty(name = "deokhugam.storage.type", havingValue = "local", matchIfMissing = true)
+@Component
+public class LocalThumbnailStorage implements ThumbnailStorage {
+
+  @Value("${deokhugam.storage.local.root-path")
+  private String uploadDir;
+
+  @PostConstruct
+  public void init() {
+    try {
+      Files.createDirectories(Paths.get(uploadDir));
+    } catch (IOException e) {
+      throw new RuntimeException("로컬 스토리지 디렉토리를 생성할 수 없습니다.", e);
+    }
+  }
+
+  @Override
+  public String upload(MultipartFile image) throws IOException {
+    String originalFilename = image.getOriginalFilename();
+    String extension = "";
+    if (originalFilename != null && originalFilename.contains(".")) {
+      extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+    }
+
+    String key = UUID.randomUUID().toString() + extension;
+    Path targetLocation = Paths.get(uploadDir).resolve(key);
+
+    Files.copy(image.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+    return key;
+  }
+
+  @Override
+  public void delete(String key) {
+    if (key == null || key.isBlank()) return;
+    try {
+      Path targetLocation = Paths.get(uploadDir).resolve(key);
+      Files.deleteIfExists(targetLocation);
+    } catch (IOException e) {
+      log.error("로컬 파일 삭제 실패: {}", key, e);
+    }
+  }
+
+  @Override
+  public String generatePresignUrl(String key) {
+    if (key == null || key.isBlank()) return null;
+
+    return "/images/thumbnails/" + key;
+  }
+}

--- a/src/main/java/com/team01/deokhugam/book/storage/S3ThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/S3ThumbnailStorage.java
@@ -1,0 +1,71 @@
+package com.team01.deokhugam.book.storage;
+
+import java.io.IOException;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ConditionalOnProperty(name = "deokhugam.storage.type", havingValue = "s3")
+@Component
+public class S3ThumbnailStorage implements ThumbnailStorage{
+  private final S3Client s3Client;
+  private final String bucket;
+
+  public S3ThumbnailStorage(
+      @Value("${deokhugam.storage.s3.access-key}") String accessKey,
+      @Value("${deokhugam.storage.s3.secret-key}") String secretKey,
+      @Value("${deokhugam.storage.s3.region}") String region,
+      @Value("${deokhugam.storage.s3.bucket}") String bucket
+  ){
+    this.bucket = bucket;
+    // 공통 자격 증명
+    StaticCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+        AwsBasicCredentials.create(accessKey, secretKey)
+    );
+
+    this.s3Client = S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(credentialsProvider)
+        .build();
+  }
+
+  @Override
+  public String upload(MultipartFile image) throws IOException {
+    String imageOriginalName = image.getOriginalFilename();
+    String extension = "";
+
+    if(imageOriginalName != null && imageOriginalName.contains(".")){
+      extension = imageOriginalName.substring(imageOriginalName.indexOf("."));
+    }
+    // 고유한 파일명 생성 = UUID, 확장자
+    String key = UUID.randomUUID().toString() + extension;
+
+    PutObjectRequest request = PutObjectRequest.builder()
+        .key(key)
+        .bucket(bucket)
+        .contentType(image.getContentType())
+        .build();
+
+    s3Client.putObject(request, RequestBody.fromBytes(image.getBytes()));
+    return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(key)).toString();
+  }
+
+  @Override
+  public void delete(String s3Url) {
+    if(s3Url == null || !s3Url.contains(".amazonaws.com/")){
+      return;
+    }
+
+    String key = s3Url.substring(s3Url.indexOf(".amazonaws.com/") + 15);
+
+    s3Client.deleteObject(builder -> builder.bucket(bucket).key(key));
+  }
+}

--- a/src/main/java/com/team01/deokhugam/book/storage/S3ThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/S3ThumbnailStorage.java
@@ -1,29 +1,37 @@
 package com.team01.deokhugam.book.storage;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @ConditionalOnProperty(name = "deokhugam.storage.type", havingValue = "s3")
 @Component
 public class S3ThumbnailStorage implements ThumbnailStorage{
   private final S3Client s3Client;
+  private final S3Presigner s3Presigner;
   private final String bucket;
+  private final int expireMinutes;
 
   public S3ThumbnailStorage(
       @Value("${deokhugam.storage.s3.access-key}") String accessKey,
       @Value("${deokhugam.storage.s3.secret-key}") String secretKey,
       @Value("${deokhugam.storage.s3.region}") String region,
-      @Value("${deokhugam.storage.s3.bucket}") String bucket
+      @Value("${deokhugam.storage.s3.bucket}") String bucket,
+      @Value("${deokhugam.storage.s3.presigned-url-expiration}") int expireMinutes
   ){
     this.bucket = bucket;
     // 공통 자격 증명
@@ -35,10 +43,22 @@ public class S3ThumbnailStorage implements ThumbnailStorage{
         .region(Region.of(region))
         .credentialsProvider(credentialsProvider)
         .build();
+
+    this.s3Presigner = S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(credentialsProvider)
+        .build();
+
+    this.expireMinutes = expireMinutes;
   }
 
   @Override
   public String upload(MultipartFile image) throws IOException {
+    String contentType = image.getContentType();
+    if (!StringUtils.hasText(contentType) || !contentType.startsWith("image/")) {
+        throw new IllegalArgumentException("이미지 파일만 업로드할 수 있습니다.");
+      }
+
     String imageOriginalName = image.getOriginalFilename();
     String extension = "";
 
@@ -54,18 +74,37 @@ public class S3ThumbnailStorage implements ThumbnailStorage{
         .contentType(image.getContentType())
         .build();
 
-    s3Client.putObject(request, RequestBody.fromBytes(image.getBytes()));
-    return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(key)).toString();
+    s3Client.putObject(request, RequestBody.fromInputStream(image.getInputStream(), image.getSize()));
+    return key;
   }
 
   @Override
-  public void delete(String s3Url) {
-    if(s3Url == null || !s3Url.contains(".amazonaws.com/")){
+  public void delete(String key) {
+    if(!StringUtils.hasText(key)){
       return;
     }
 
-    String key = s3Url.substring(s3Url.indexOf(".amazonaws.com/") + 15);
-
     s3Client.deleteObject(builder -> builder.bucket(bucket).key(key));
+  }
+
+  @Override
+  public String generatePresignUrl(String key) {
+
+    // 어떤 파일을 가져올지 요청
+    GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+        .bucket(bucket)
+        .key(key)
+        .build();
+
+    // 얼마나 허용할지 시간을 설정
+    GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+        // 유효기간
+        .signatureDuration(Duration.ofMinutes(expireMinutes))
+        .getObjectRequest(getObjectRequest)
+        .build();
+
+
+    // 문자열로 반환
+    return s3Presigner.presignGetObject(presignRequest).url().toString();
   }
 }

--- a/src/main/java/com/team01/deokhugam/book/storage/S3ThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/S3ThumbnailStorage.java
@@ -63,7 +63,7 @@ public class S3ThumbnailStorage implements ThumbnailStorage{
     String extension = "";
 
     if(imageOriginalName != null && imageOriginalName.contains(".")){
-      extension = imageOriginalName.substring(imageOriginalName.indexOf("."));
+      extension = imageOriginalName.substring(imageOriginalName.lastIndexOf("."));
     }
     // 고유한 파일명 생성 = UUID, 확장자
     String key = UUID.randomUUID().toString() + extension;
@@ -89,6 +89,9 @@ public class S3ThumbnailStorage implements ThumbnailStorage{
 
   @Override
   public String generatePresignUrl(String key) {
+    if (!StringUtils.hasText(key)) {
+      return null;
+    }
 
     // 어떤 파일을 가져올지 요청
     GetObjectRequest getObjectRequest = GetObjectRequest.builder()

--- a/src/main/java/com/team01/deokhugam/book/storage/ThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/ThumbnailStorage.java
@@ -1,10 +1,15 @@
 package com.team01.deokhugam.book.storage;
 
 import java.io.IOException;
+import org.mapstruct.Named;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ThumbnailStorage {
   String upload(MultipartFile image) throws IOException;
 
   void delete(String s3Url);
+
+  // mapstruct가 해당 이름으로 찾을 수 있게함
+  @Named("toPresignedUrl")
+  String generatePresignUrl(String key);
 }

--- a/src/main/java/com/team01/deokhugam/book/storage/ThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/ThumbnailStorage.java
@@ -7,7 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ThumbnailStorage {
   String upload(MultipartFile image) throws IOException;
 
-  void delete(String s3Url);
+  void delete(String key);
 
   // mapstruct가 해당 이름으로 찾을 수 있게함
   @Named("toPresignedUrl")

--- a/src/main/java/com/team01/deokhugam/book/storage/ThumbnailStorage.java
+++ b/src/main/java/com/team01/deokhugam/book/storage/ThumbnailStorage.java
@@ -1,0 +1,10 @@
+package com.team01.deokhugam.book.storage;
+
+import java.io.IOException;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ThumbnailStorage {
+  String upload(MultipartFile image) throws IOException;
+
+  void delete(String s3Url);
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,7 +55,7 @@ info:
 
 deokhugam:
   storage:
-    type: ${STORAGE_TYPE:local}  # local | s3 (기본값: local)
+    type: ${STORAGE_TYPE:s3}  # local | s3 (기본값: s3)
     local:
       root-path: ${STORAGE_LOCAL_ROOT_PATH:.deokhugam/storage}
     s3:

--- a/src/test/java/com/team01/deokhugam/book/BookServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/book/BookServiceTest.java
@@ -16,6 +16,7 @@ import com.team01.deokhugam.book.dto.BookDto;
 import com.team01.deokhugam.book.entity.Book;
 import com.team01.deokhugam.book.repository.BookRepository;
 import com.team01.deokhugam.book.service.BookService;
+import com.team01.deokhugam.book.storage.S3ThumbnailStorage;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.book.BookNotFoundException;
 import com.team01.deokhugam.book.dto.BookUpdateRequest;
@@ -54,6 +55,9 @@ class BookServiceTest {
   @Mock
   private RestClient ocrRestClient;
 
+  @Mock
+  private S3ThumbnailStorage s3ThumbnailStorage;
+
   @InjectMocks
   private BookService bookService;
 
@@ -63,7 +67,7 @@ class BookServiceTest {
 
   @BeforeEach
   void setUp() {
-    bookService = new BookService(bookMapper, bookRepository, naverRestClient, defaultRestClient, ocrRestClient);
+    bookService = new BookService(bookMapper, bookRepository, naverRestClient, defaultRestClient, ocrRestClient, s3ThumbnailStorage);
     // 테스트에 사용할 공통 데이터 세팅
     request = new BookCreateRequest(
         "테스트 도서",


### PR DESCRIPTION
## 📌 관련 이슈

- closes #100 

## 📝 작업 내용

- s3 저장소 인터페이스, 클래스 생성, upload ,delete 메서드 구현
- book 엔티티 썸네일 수정 로직 추가
- builde.gradle 의존성 라이브러리 추가

## 💡 변경 사항

- 변경사항 1

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AWS S3 및 로컬을 선택 가능한 썸네일 저장소 통합 추가
  * 책 생성·수정 시 썸네일 업로드 및 썸네일 URL 생성(사전 서명 URL 포함)
* **동작 변경**
  * 트랜잭션 커밋/롤백에 따라 외부 썸네일 객체 삭제 동기화 적용
  * 책 영구 삭제 시 연관 썸네일 삭제 수행
* **테스트**
  * 썸네일 저장소 의존성에 맞춰 테스트 업데이트
* **잡업(Chores)**
  * AWS SDK v2 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->