### PR TITLE
feat: 리뷰 삭제 기능 구현 #46

### DIFF
--- a/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
@@ -26,7 +26,12 @@ public enum ErrorCode {
   // review
   REVIEW_NOT_FOUND(404, "REVIEW_NOT_FOUND", "리뷰를 찾을 수 없습니다."),
   REVIEW_UPDATE_FORBIDDEN(403, "REVIEW_UPDATE_FORBIDDEN", "리뷰를 수정할 권한이 없습니다."),
-
+  REVIEW_CONTENT_NULL(400, "REVIEW_CONTENT_NULL", "리뷰 내용은 null일 수 없습니다."),
+  REVIEW_CONTENT_BLANK(400, "REVIEW_CONTENT_BLANK", "리뷰 내용은 비어 있을 수 없습니다."),
+  REVIEW_CONTENT_TOO_LONG(400, "REVIEW_CONTENT_TOO_LONG", "리뷰는 1000자를 초과할 수 없습니다."),
+  REVIEW_RATING_OUT_OF_RANGE(400, "REVIEW_RATING_OUT_OF_RANGE", "평점은 1.0 이상 5.0 이하여야 합니다."),
+  REVIEW_ALREADY_EXISTS(409, "REVIEW_ALREADY_EXISTS", "해당 도서에 작성한 리뷰가 있습니다."),
+  REVIEW_NOT_SOFT_DELETED(400, "REVIEW_NOT_SOFT_DELETED", "논리 삭제된 리뷰만 물리 삭제할 수 있습니다."),
   // user
   EMAIL_ALREADY_EXISTS(409, "EMAIL_ALREADY_EXISTS", "이미 등록된 이메일입니다."),
   USER_NOT_FOUND(404, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/team01/deokhugam/global/exception/pagination/InvalidCursorPaginationException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/pagination/InvalidCursorPaginationException.java
@@ -1,0 +1,17 @@
+package com.team01.deokhugam.global.exception.pagination;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+
+public class InvalidCursorPaginationException extends DeokhugamException {
+
+  public InvalidCursorPaginationException() {
+    super(
+        ErrorCode.INVALID_CURSOR_PAGINATION,
+        Map.of(
+            "rule", "cursor와 after는 함께 제공되어야 합니다."
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewAlreadyExistsException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewAlreadyExistsException.java
@@ -1,0 +1,20 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class ReviewAlreadyExistsException extends DeokhugamException {
+
+  public ReviewAlreadyExistsException(UUID bookId, UUID userId) {
+    super(
+        ErrorCode.REVIEW_ALREADY_EXISTS,
+        Map.of(
+            "bookId", bookId.toString(),
+            "userId", userId.toString(),
+            "rule", "해당 도서에 작성한 리뷰가 있습니다"
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewContentBlankException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewContentBlankException.java
@@ -1,0 +1,15 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+
+public class ReviewContentBlankException extends DeokhugamException {
+
+  public ReviewContentBlankException() {
+    super(
+        ErrorCode.REVIEW_CONTENT_BLANK,
+        Map.of("rule", "리뷰 내용은 비어 있을 수 없습니다.")
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewContentNullException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewContentNullException.java
@@ -1,0 +1,15 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+
+public class ReviewContentNullException extends DeokhugamException {
+
+  public ReviewContentNullException() {
+    super(
+        ErrorCode.REVIEW_CONTENT_NULL,
+        Map.of("rule", "리뷰 내용은 NULL일 수 없습니다.")
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewContentTooLongException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewContentTooLongException.java
@@ -1,0 +1,18 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+
+public class ReviewContentTooLongException extends DeokhugamException {
+
+  public ReviewContentTooLongException(int maxLength) {
+    super(
+        ErrorCode.REVIEW_CONTENT_TOO_LONG,
+        Map.of(
+            "maxLength", maxLength,
+            "rule", "리뷰는 1000자를 초과할 수 없습니다."
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewNotFoundException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewNotFoundException.java
@@ -1,0 +1,21 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class ReviewNotFoundException extends DeokhugamException {
+
+  public ReviewNotFoundException(UUID reviewId) {
+    super(
+        ErrorCode.REVIEW_NOT_FOUND,
+        Map.of(
+            "reviewId",
+            reviewId.toString(),
+            "rule",
+            "리뷰를 찾을 수 없습니다."
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewNotSoftDeletedException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewNotSoftDeletedException.java
@@ -1,0 +1,17 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+
+public class ReviewNotSoftDeletedException extends DeokhugamException {
+
+  public ReviewNotSoftDeletedException() {
+    super(
+        ErrorCode.REVIEW_NOT_SOFT_DELETED,
+        Map.of(
+            "rule", "논리 삭제된 리뷰만 물리 삭제할 수 있습니다."
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewRatingOutOfRangeException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewRatingOutOfRangeException.java
@@ -1,0 +1,20 @@
+package com.team01.deokhugam.global.exception.review;
+
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+
+public class ReviewRatingOutOfRangeException extends DeokhugamException {
+
+  public ReviewRatingOutOfRangeException(double rating) {
+    super(
+        ErrorCode.REVIEW_RATING_OUT_OF_RANGE,
+        Map.of(
+            "rating", rating,
+            "min", 1.0,
+            "max", 5.0,
+            "rule", "평점은 1.0 이상 5.0 이하여야 합니다."
+        )
+    );
+  }
+}

--- a/src/main/java/com/team01/deokhugam/global/exception/review/ReviewUpdateForbiddenException.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/review/ReviewUpdateForbiddenException.java
@@ -5,9 +5,9 @@ import com.team01.deokhugam.global.exception.ErrorCode;
 import java.util.Map;
 import java.util.UUID;
 
-public class ReviewUpdateForbidden extends DeokhugamException {
+public class ReviewUpdateForbiddenException extends DeokhugamException {
 
-  public ReviewUpdateForbidden(UUID reviewId, UUID requestUserId) {
+  public ReviewUpdateForbiddenException(UUID reviewId, UUID requestUserId) {
     super(
         ErrorCode.REVIEW_UPDATE_FORBIDDEN,
         Map.of(

--- a/src/main/java/com/team01/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/team01/deokhugam/review/controller/ReviewController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -112,5 +113,37 @@ public class ReviewController {
   ) {
     ReviewDto response = reviewService.updateReview(reviewId, requestUserId, request);
     return ResponseEntity.ok(response);
+  }
+
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "리뷰 논리 삭제 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청(요청자 ID누락)"),
+      @ApiResponse(responseCode = "403", description = "리뷰 삭제 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "리뷰 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @DeleteMapping("/{reviewId}")
+  public ResponseEntity<Void> deleteReview(
+      @PathVariable UUID reviewId,
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId
+  ) {
+    reviewService.deleteReview(reviewId, requestUserId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "리뷰 물리 삭제 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청(요청자 ID누락, 논리 삭제되지 않은 리뷰)"),
+      @ApiResponse(responseCode = "403", description = "리뷰 삭제 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "리뷰 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @DeleteMapping("/{reviewId}/hard")
+  public ResponseEntity<Void> hardDeleteReview(
+      @PathVariable UUID reviewId,
+      @RequestHeader(AuthHeader.REQUEST_USER_ID) UUID requestUserId
+  ) {
+    reviewService.hardDeleteReview(reviewId, requestUserId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/team01/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/team01/deokhugam/review/entity/Review.java
@@ -1,17 +1,25 @@
 package com.team01.deokhugam.review.entity;
 
 import com.team01.deokhugam.book.entity.Book;
+import com.team01.deokhugam.comment.entity.Comment;
 import com.team01.deokhugam.global.entity.BaseRemovableEntity;
+import com.team01.deokhugam.global.exception.review.ReviewContentBlankException;
+import com.team01.deokhugam.global.exception.review.ReviewContentNullException;
+import com.team01.deokhugam.global.exception.review.ReviewContentTooLongException;
+import com.team01.deokhugam.global.exception.review.ReviewRatingOutOfRangeException;
 import com.team01.deokhugam.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-import java.util.Objects;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +37,6 @@ import lombok.NoArgsConstructor;
     }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-
 public class Review extends BaseRemovableEntity {
 
   // 리뷰가 달린 도서
@@ -58,14 +65,17 @@ public class Review extends BaseRemovableEntity {
   @Column(name = "comment_count", nullable = false)
   private int commentCount;
 
+  // 리뷰에 달린 댓글
+  @OneToMany(mappedBy = "review", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<Comment> comments = new ArrayList<>();
+
+
   // 낙관적 락
   @Version
   @Column(name = "version", nullable = false)
   private Long version;
 
   public Review(Book book, User user, String content, double rating) {
-    validateBook(book);
-    validateUser(user);
     validateContent(content);
     validateRating(rating);
 
@@ -110,33 +120,26 @@ public class Review extends BaseRemovableEntity {
     }
   }
 
-  private void validateBook(Book book) {
-    Objects.requireNonNull(book, "도서 정보는 null일 수 없습니다.");
-  }
-
-  private void validateUser(User user) {
-    Objects.requireNonNull(user, "사용자 정보는 null일 수 없습니다.");
-  }
-
   private void validateContent(String content) {
     if (content == null) {
-      throw new IllegalArgumentException("리뷰 내용은 null일 수 없습니다.");
+      throw new ReviewContentNullException();
     }
 
     String trimmedContent = content.trim();
 
     if (trimmedContent.isEmpty()) {
-      throw new IllegalArgumentException("리뷰 내용은 비어 있을 수 없습니다.");
+      throw new ReviewContentBlankException();
     }
 
     if (trimmedContent.length() > 1000) {
-      throw new IllegalArgumentException("리뷰는 1000자를 초과할 수 없습니다.");
+      throw new ReviewContentTooLongException(1000);
     }
   }
 
+
   private void validateRating(double rating) {
     if (rating < 1.0 || rating > 5.0) {
-      throw new IllegalArgumentException("평점은 1.0 이상 5.0 이하여야 합니다.");
+      throw new ReviewRatingOutOfRangeException(rating);
     }
   }
 }

--- a/src/main/java/com/team01/deokhugam/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/team01/deokhugam/review/mapper/ReviewMapper.java
@@ -1,5 +1,6 @@
 package com.team01.deokhugam.review.mapper;
 
+import com.team01.deokhugam.book.storage.ThumbnailStorage;
 import com.team01.deokhugam.review.dto.ReviewDto;
 import com.team01.deokhugam.review.entity.Review;
 import java.time.OffsetDateTime;
@@ -8,13 +9,14 @@ import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", imports = {OffsetDateTime.class, ZoneOffset.class})
+@Mapper(componentModel = "spring", imports = {OffsetDateTime.class, ZoneOffset.class}, uses = {
+    ThumbnailStorage.class})
 public interface ReviewMapper {
 
   // Review 엔티티를 ReviewDto로 변환
   @Mapping(target = "bookId", source = "book.id")
   @Mapping(target = "bookTitle", source = "book.title")
-  @Mapping(target = "bookThumbnailUrl", source = "book.thumbnailUrl")
+  @Mapping(target = "bookThumbnailUrl", source = "book.thumbnailUrl", qualifiedByName = "toPresignedUrl")
   @Mapping(target = "userId", source = "user.id")
   @Mapping(target = "userNickname", source = "user.nickname")
   @Mapping(target = "likedByMe", ignore = true)

--- a/src/main/java/com/team01/deokhugam/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/repository/ReviewRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.team01.deokhugam.review.repository;
 
 import com.team01.deokhugam.global.enums.SortDirection;
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
 import com.team01.deokhugam.review.dto.ReviewSearchCondition;
 import com.team01.deokhugam.review.entity.Review;
 import jakarta.persistence.EntityManager;
@@ -35,9 +37,11 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     boolean hasAfter = after != null;
 
     if (hasAfter != hasCursor) {
-      throw new IllegalArgumentException("after와 cursor는 같이 전달 되어야 합니다.");
+      throw new DeokhugamException(
+          ErrorCode.INVALID_CURSOR_PAGINATION,
+          Map.of("rule", "cursor와 after는 함께 제공되어야 합니다.")
+      );
     }
-
     String comparisonOperator = isAsc ? ">" : "<";
 
     QueryParts queryParts = buildFilterQueryParts(condition);
@@ -166,29 +170,29 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     try {
       return UUID.fromString(cursor);
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("cursor 형식이 올바르지 않습니다.");
+      throw new DeokhugamException(ErrorCode.INVALID_CURSOR_FORMAT, Map.of("cursor", cursor));
     }
   }
 
   private RatingCursor parseRatingCursor(String cursor) {
     if (!StringUtils.hasText(cursor)) {
-      throw new IllegalArgumentException("rating 정렬 cursor 형식이 올바르지 않습니다.");
+      throw new DeokhugamException(ErrorCode.INVALID_CURSOR_FORMAT, Map.of("cursor", cursor));
     }
 
     String[] parts = cursor.split("\\|", 2);
     if (parts.length != 2) {
-      throw new IllegalArgumentException("rating 정렬 cursor 형식이 올바르지 않습니다.");
+      throw new DeokhugamException(ErrorCode.INVALID_CURSOR_FORMAT, Map.of("cursor", cursor));
     }
 
     try {
       double rating = Double.parseDouble(parts[0]);
       if (!Double.isFinite(rating)) {
-        throw new IllegalArgumentException("rating 정렬 cursor 형식이 올바르지 않습니다.");
+        throw new DeokhugamException(ErrorCode.INVALID_CURSOR_FORMAT, Map.of("cursor", cursor));
       }
       UUID id = UUID.fromString(parts[1]);
       return new RatingCursor(rating, id);
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("rating 정렬 cursor 형식이 올바르지 않습니다.");
+      throw new DeokhugamException(ErrorCode.INVALID_CURSOR_FORMAT, Map.of("cursor", cursor));
     }
   }
 

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewService.java
@@ -27,4 +27,10 @@ public interface ReviewService {
   );
 
   ReviewDto updateReview(UUID reviewId, UUID requestUserId, ReviewUpdateRequest request);
+
+  // 논리 삭제
+  void deleteReview(UUID reviewId, UUID requestUserId);
+
+  // 물리 삭제
+  void hardDeleteReview(UUID reviewId, UUID requestUserId);
 }

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
@@ -146,4 +146,41 @@ public class ReviewServiceImpl implements ReviewService {
 
     return reviewMapper.toDto(review);
   }
+
+  @Override
+  @Transactional
+  public void deleteReview(UUID reviewId, UUID requestUserId) {
+    // 리뷰  존재 검증
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
+        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+    // 사용자가 쓴 리뷰인지 검증
+    if (!review.getUser().getId().equals(requestUserId)) {
+      throw new ReviewUpdateForbidden(reviewId, requestUserId);
+    }
+
+    // 리뷰 논리 삭제
+    review.softDelete();
+  }
+
+  @Override
+  @Transactional
+  public void hardDeleteReview(UUID reviewId, UUID requestUserId) {
+    // 리뷰 존재 검증
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+    // 사용자가 쓴 리뷰인지 검증
+    if (!review.getUser().getId().equals(requestUserId)) {
+      throw new ReviewUpdateForbidden(reviewId, requestUserId);
+    }
+
+    // 논리 삭제된 리뷰인지 검증
+    if (!review.isDeleted()) {
+      throw new IllegalArgumentException("논리 삭제된 리뷰만 물리 삭제할 수 있습니다.");
+    }
+
+    // 물리 삭제
+    reviewRepository.delete(review);
+  }
 }

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
@@ -4,7 +4,11 @@ import com.team01.deokhugam.book.entity.Book;
 import com.team01.deokhugam.book.repository.BookRepository;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.book.BookNotFoundException;
-import com.team01.deokhugam.global.exception.review.ReviewUpdateForbidden;
+import com.team01.deokhugam.global.exception.review.ReviewAlreadyExistsException;
+import com.team01.deokhugam.global.exception.review.ReviewNotFoundException;
+import com.team01.deokhugam.global.exception.review.ReviewNotSoftDeletedException;
+import com.team01.deokhugam.global.exception.review.ReviewUpdateForbiddenException;
+import com.team01.deokhugam.global.exception.user.UserNotFoundException;
 import com.team01.deokhugam.global.pagination.CursorPageResponse;
 import com.team01.deokhugam.global.pagination.CursorPaginationUtils;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
@@ -43,12 +47,12 @@ public class ReviewServiceImpl implements ReviewService {
 
     //사용자 확인
     User user = userRepository.findById(request.userId())
-        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        .orElseThrow(() -> new UserNotFoundException(request.userId()));
 
     // 리뷰 중복확인
     if (reviewRepository.existsByBook_IdAndUser_IdAndIsDeletedFalse(request.bookId(),
         request.userId())) {
-      throw new IllegalArgumentException("해당 도서에 작성한 리뷰가 있습니다.");
+      throw new ReviewAlreadyExistsException(request.bookId(), request.userId());
     }
 
     // 리뷰 엔티티 생성
@@ -67,7 +71,7 @@ public class ReviewServiceImpl implements ReviewService {
   public ReviewDto getReview(UUID reviewId, UUID requestUserId) {
     // 리뷰 검증
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
-        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+        .orElseThrow(() -> new ReviewNotFoundException(reviewId));
 
     /*TODO 리뷰 좋아요 기능 아직 구현 전 이라 구현 후  likedByMe 결과값 반영
        likedByMe에 requestUserId 사용
@@ -134,11 +138,11 @@ public class ReviewServiceImpl implements ReviewService {
 
     // 리뷰  존재 검증
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
-        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+        .orElseThrow(() -> new ReviewNotFoundException(reviewId));
 
     // 사용자가 쓴 리뷰인지 검증
     if (!review.getUser().getId().equals(requestUserId)) {
-      throw new ReviewUpdateForbidden(reviewId, requestUserId);
+      throw new ReviewUpdateForbiddenException(reviewId, requestUserId);
     }
 
     // 리뷰 수정
@@ -152,11 +156,11 @@ public class ReviewServiceImpl implements ReviewService {
   public void deleteReview(UUID reviewId, UUID requestUserId) {
     // 리뷰  존재 검증
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
-        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+        .orElseThrow(() -> new ReviewNotFoundException(reviewId));
 
     // 사용자가 쓴 리뷰인지 검증
     if (!review.getUser().getId().equals(requestUserId)) {
-      throw new ReviewUpdateForbidden(reviewId, requestUserId);
+      throw new ReviewUpdateForbiddenException(reviewId, requestUserId);
     }
 
     // 리뷰 논리 삭제
@@ -168,16 +172,16 @@ public class ReviewServiceImpl implements ReviewService {
   public void hardDeleteReview(UUID reviewId, UUID requestUserId) {
     // 리뷰 존재 검증
     Review review = reviewRepository.findById(reviewId)
-        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+        .orElseThrow(() -> new ReviewNotFoundException(reviewId));
 
     // 사용자가 쓴 리뷰인지 검증
     if (!review.getUser().getId().equals(requestUserId)) {
-      throw new ReviewUpdateForbidden(reviewId, requestUserId);
+      throw new ReviewUpdateForbiddenException(reviewId, requestUserId);
     }
 
     // 논리 삭제된 리뷰인지 검증
     if (!review.isDeleted()) {
-      throw new IllegalArgumentException("논리 삭제된 리뷰만 물리 삭제할 수 있습니다.");
+      throw new ReviewNotSoftDeletedException();
     }
 
     // 물리 삭제

--- a/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
@@ -2,7 +2,9 @@ package com.team01.deokhugam.review.controller;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -269,5 +271,57 @@ class ReviewControllerTest {
             .contentType(APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("리뷰 논리 삭제 - 성공")
+  void deleteReview_success() throws Exception {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/reviews/{reviewId}", reviewId)
+            .header("Deokhugam-Request-User-ID", requestUserId))
+        .andExpect(status().isNoContent());
+
+    verify(reviewService).deleteReview(reviewId, requestUserId);
+  }
+
+  @Test
+  @DisplayName("리뷰 논리 삭제 - 요청자 헤더가 없으면 실패")
+  void deleteReview_fail_whenMissingHeader() throws Exception {
+    // given
+    UUID reviewId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/reviews/{reviewId}", reviewId))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("리뷰 물리 삭제 - 성공")
+  void hardDeleteReview_success() throws Exception {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/reviews/{reviewId}/hard", reviewId)
+            .header("Deokhugam-Request-User-ID", requestUserId))
+        .andExpect(status().isNoContent());
+
+    verify(reviewService).hardDeleteReview(reviewId, requestUserId);
+  }
+
+  @Test
+  @DisplayName("리뷰 물리 삭제 - 요청자 헤더가 없으면 실패")
+  void hardDeleteReview_fail_whenMissingHeader() throws Exception {
+    // given
+    UUID reviewId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/reviews/{reviewId}/hard", reviewId))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/review/controller/ReviewControllerTest.java
@@ -13,7 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team01.deokhugam.global.enums.SortDirection;
-import com.team01.deokhugam.global.exception.review.ReviewUpdateForbidden;
+import com.team01.deokhugam.global.exception.review.ReviewUpdateForbiddenException;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
@@ -263,7 +263,7 @@ class ReviewControllerTest {
     ReviewUpdateRequest request = new ReviewUpdateRequest("수정 시도", 4.5);
 
     given(reviewService.updateReview(reviewId, requestUserId, request))
-        .willThrow(new ReviewUpdateForbidden(reviewId, requestUserId));
+        .willThrow(new ReviewUpdateForbiddenException(reviewId, requestUserId));
 
     // when & then
     mockMvc.perform(patch("/api/reviews/{reviewId}", reviewId)

--- a/src/test/java/com/team01/deokhugam/review/repository/ReviewRepositoryImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/repository/ReviewRepositoryImplTest.java
@@ -7,6 +7,8 @@ import com.team01.deokhugam.book.entity.Book;
 import com.team01.deokhugam.global.config.JpaConfig;
 import com.team01.deokhugam.global.config.QueryDslConfig;
 import com.team01.deokhugam.global.enums.SortDirection;
+import com.team01.deokhugam.global.exception.DeokhugamException;
+import com.team01.deokhugam.global.exception.ErrorCode;
 import com.team01.deokhugam.review.dto.ReviewSearchCondition;
 import com.team01.deokhugam.review.entity.Review;
 import com.team01.deokhugam.user.entity.User;
@@ -68,7 +70,6 @@ class ReviewRepositoryImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - createdAt 기준 내림차순 정렬 성공")
   void findAllByCondition_orderByCreatedAtDesc_success() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         null,
         null,
@@ -80,10 +81,8 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when
     List<Review> result = reviewRepository.findAllByCondition(condition);
 
-    // then
     assertThat(result).hasSize(4);
     assertThat(result.get(0).getContent()).isEqualTo("리뷰 테스트 4");
     assertThat(result.get(1).getContent()).isEqualTo("리뷰 테스트 3");
@@ -94,7 +93,6 @@ class ReviewRepositoryImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - rating 기준 내림차순 정렬 성공")
   void findAllByCondition_orderByRatingDesc_success() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         null,
         null,
@@ -106,10 +104,8 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when
     List<Review> result = reviewRepository.findAllByCondition(condition);
 
-    // then
     assertThat(result).hasSize(4);
     assertThat(result.get(0).getRating()).isEqualTo(5.0);
     assertThat(result.get(1).getRating()).isEqualTo(4.0);
@@ -120,7 +116,6 @@ class ReviewRepositoryImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - userId 조건으로 필터링 성공")
   void findAllByCondition_filterByUserId_success() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         user1.getId(),
         null,
@@ -132,10 +127,8 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when
     List<Review> result = reviewRepository.findAllByCondition(condition);
 
-    // then
     assertThat(result).hasSize(2);
     assertThat(result)
         .extracting(Review::getContent)
@@ -145,7 +138,6 @@ class ReviewRepositoryImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - bookId 조건으로 필터링 성공")
   void findAllByCondition_filterByBookId_success() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         null,
         book1.getId(),
@@ -157,10 +149,8 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when
     List<Review> result = reviewRepository.findAllByCondition(condition);
 
-    // then
     assertThat(result).hasSize(2);
     assertThat(result)
         .extracting(Review::getContent)
@@ -170,7 +160,6 @@ class ReviewRepositoryImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - keyword 조건으로 필터링 성공")
   void findAllByCondition_filterByKeyword_success() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         null,
         null,
@@ -182,10 +171,8 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when
     List<Review> result = reviewRepository.findAllByCondition(condition);
 
-    // then
     assertThat(result).hasSize(4);
     assertThat(result)
         .extracting(Review::getContent)
@@ -195,7 +182,6 @@ class ReviewRepositoryImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - after와 cursor로 다음 페이지 조회 성공")
   void findAllByCondition_cursorPaging_success() {
-    // given
     ReviewSearchCondition firstCondition = new ReviewSearchCondition(
         null,
         null,
@@ -209,7 +195,6 @@ class ReviewRepositoryImplTest {
 
     List<Review> firstPage = reviewRepository.findAllByCondition(firstCondition);
 
-    // when
     Review lastReviewOfFirstPage = firstPage.get(1);
 
     ReviewSearchCondition secondCondition = new ReviewSearchCondition(
@@ -225,7 +210,6 @@ class ReviewRepositoryImplTest {
 
     List<Review> secondPage = reviewRepository.findAllByCondition(secondCondition);
 
-    // then
     assertThat(firstPage).hasSize(3);
     assertThat(secondPage).hasSize(2);
     assertThat(secondPage)
@@ -236,7 +220,6 @@ class ReviewRepositoryImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - after만 전달되면 예외 발생")
   void findAllByCondition_fail_whenAfterOnly() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         null,
         null,
@@ -248,16 +231,15 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when & then
     assertThatThrownBy(() -> reviewRepository.findAllByCondition(condition))
-        .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
-        .hasMessageContaining("after와 cursor는 같이 전달 되어야 합니다.");
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_CURSOR_PAGINATION);
   }
 
   @Test
   @DisplayName("리뷰 목록 조회 - cursor만 전달되면 예외 발생")
   void findAllByCondition_fail_whenCursorOnly() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         null,
         null,
@@ -269,16 +251,15 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when & then
     assertThatThrownBy(() -> reviewRepository.findAllByCondition(condition))
-        .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
-        .hasMessageContaining("after와 cursor는 같이 전달 되어야 합니다.");
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_CURSOR_PAGINATION);
   }
 
   @Test
   @DisplayName("리뷰 개수 조회 - 조건에 맞는 개수 반환 성공")
   void countByCondition_success() {
-    // given
     ReviewSearchCondition condition = new ReviewSearchCondition(
         null,
         book1.getId(),
@@ -290,10 +271,8 @@ class ReviewRepositoryImplTest {
         10
     );
 
-    // when
     long count = reviewRepository.countByCondition(condition);
 
-    // then
     assertThat(count).isEqualTo(2);
   }
 

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -130,13 +130,12 @@ class ReviewServiceImplTest {
     given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
     given(userRepository.findById(userId)).willReturn(Optional.empty());
 
-    Exception exception = assertThrows(
-        UserNotFoundException.class,
-        () -> reviewServiceImpl.createReview(reviewCreateRequest)
-    );
-
-    assertThat(exception.getMessage()).isEqualTo("사용자를 찾을 수 없습니다.");
+    assertThatThrownBy(() -> reviewServiceImpl.createReview(reviewCreateRequest))
+        .isInstanceOf(UserNotFoundException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.USER_NOT_FOUND);
   }
+
 
   @Test
   @DisplayName("리뷰 생성 - 같은 유저가 같은 도서에 중복 리뷰 작성 시 예외 발생")
@@ -152,12 +151,10 @@ class ReviewServiceImplTest {
     given(reviewRepository.existsByBook_IdAndUser_IdAndIsDeletedFalse(bookId, userId))
         .willReturn(true);
 
-    Exception exception = assertThrows(
-        ReviewAlreadyExistsException.class,
-        () -> reviewServiceImpl.createReview(reviewCreateRequest)
-    );
-
-    assertThat(exception.getMessage()).isEqualTo("해당 도서에 작성한 리뷰가 있습니다.");
+    assertThatThrownBy(() -> reviewServiceImpl.createReview(reviewCreateRequest))
+        .isInstanceOf(ReviewAlreadyExistsException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_ALREADY_EXISTS);
   }
 
   @Test
@@ -184,12 +181,10 @@ class ReviewServiceImplTest {
   void getReview_fail_whenReviewNotFound() {
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
 
-    Exception exception = assertThrows(
-        ReviewNotFoundException.class,
-        () -> reviewServiceImpl.getReview(reviewId, requestUserId)
-    );
-
-    assertThat(exception.getMessage()).isEqualTo("리뷰를 찾을 수 없습니다.");
+    assertThatThrownBy(() -> reviewServiceImpl.getReview(reviewId, requestUserId))
+        .isInstanceOf(ReviewNotFoundException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
   }
 
   @Test
@@ -343,7 +338,8 @@ class ReviewServiceImplTest {
 
     assertThatThrownBy(() -> reviewServiceImpl.deleteReview(reviewId, requestUserId))
         .isInstanceOf(ReviewNotFoundException.class)
-        .hasMessage("리뷰를 찾을 수 없습니다.");
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
   }
 
   @Test
@@ -387,7 +383,8 @@ class ReviewServiceImplTest {
 
     assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
         .isInstanceOf(ReviewNotFoundException.class)
-        .hasMessage("리뷰를 찾을 수 없습니다.");
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
   }
 
   @Test
@@ -421,7 +418,8 @@ class ReviewServiceImplTest {
 
     assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
         .isInstanceOf(ReviewNotSoftDeletedException.class)
-        .hasMessage("논리 삭제된 리뷰만 물리 삭제할 수 있습니다.");
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_NOT_SOFT_DELETED);
 
     verify(reviewRepository, never()).delete(any(Review.class));
   }

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -372,4 +372,148 @@ class ReviewServiceImplTest {
 
     verify(review, never()).update(anyString(), anyDouble());
   }
+
+  @Test
+  @DisplayName("리뷰 논리 삭제 - 성공")
+  void deleteReview_success() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    User author = mock(User.class);
+    Review review = mock(Review.class);
+
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
+    given(review.getUser()).willReturn(author);
+    given(author.getId()).willReturn(requestUserId);
+
+    // when
+    reviewServiceImpl.deleteReview(reviewId, requestUserId);
+
+    // then
+    verify(review).softDelete();
+  }
+
+  @Test
+  @DisplayName("리뷰 논리 삭제 - 리뷰가 없으면 예외 발생")
+  void deleteReview_fail_whenReviewNotFound() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> reviewServiceImpl.deleteReview(reviewId, requestUserId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("리뷰를 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("리뷰 논리 삭제 - 권한 없는 사용자가 삭제 시 예외 발생")
+  void deleteReview_fail_whenRequesterIsNotAuthor() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID authorId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    User author = mock(User.class);
+    Review review = mock(Review.class);
+
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
+    given(review.getUser()).willReturn(author);
+    given(author.getId()).willReturn(authorId);
+
+    // when & then
+    assertThatThrownBy(() -> reviewServiceImpl.deleteReview(reviewId, requestUserId))
+        .isInstanceOf(ReviewUpdateForbidden.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_UPDATE_FORBIDDEN);
+
+    verify(review, never()).softDelete();
+  }
+
+  @Test
+  @DisplayName("리뷰 물리 삭제 - 성공")
+  void hardDeleteReview_success() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    User author = mock(User.class);
+    Review review = mock(Review.class);
+
+    given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+    given(review.getUser()).willReturn(author);
+    given(author.getId()).willReturn(requestUserId);
+    given(review.isDeleted()).willReturn(true);
+
+    // when
+    reviewServiceImpl.hardDeleteReview(reviewId, requestUserId);
+
+    // then
+    verify(reviewRepository).delete(review);
+  }
+
+  @Test
+  @DisplayName("리뷰 물리 삭제 - 리뷰가 없으면 예외 발생")
+  void hardDeleteReview_fail_whenReviewNotFound() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("리뷰를 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("리뷰 물리 삭제 - 권한 없는 사용자가 삭제 시 예외 발생")
+  void hardDeleteReview_fail_whenRequesterIsNotAuthor() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID authorId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    User author = mock(User.class);
+    Review review = mock(Review.class);
+
+    given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+    given(review.getUser()).willReturn(author);
+    given(author.getId()).willReturn(authorId);
+
+    // when & then
+    assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
+        .isInstanceOf(ReviewUpdateForbidden.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.REVIEW_UPDATE_FORBIDDEN);
+
+    verify(reviewRepository, never()).delete(any(Review.class));
+  }
+
+  @Test
+  @DisplayName("리뷰 물리 삭제 - 논리 삭제되지 않은 리뷰면 예외 발생")
+  void hardDeleteReview_fail_whenReviewIsNotSoftDeleted() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+
+    User author = mock(User.class);
+    Review review = mock(Review.class);
+
+    given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+    given(review.getUser()).willReturn(author);
+    given(author.getId()).willReturn(requestUserId);
+    given(review.isDeleted()).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("논리 삭제된 리뷰만 물리 삭제할 수 있습니다.");
+
+    verify(reviewRepository, never()).delete(any(Review.class));
+  }
 }

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -16,7 +16,7 @@ import com.team01.deokhugam.book.repository.BookRepository;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.ErrorCode;
 import com.team01.deokhugam.global.exception.book.BookNotFoundException;
-import com.team01.deokhugam.global.exception.review.ReviewUpdateForbidden;
+import com.team01.deokhugam.global.exception.review.ReviewUpdateForbiddenException;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
@@ -39,72 +39,63 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class) // Mockito 기반 단위 테스트
+@ExtendWith(MockitoExtension.class)
 class ReviewServiceImplTest {
 
   @Mock
-  private ReviewRepository reviewRepository; // 리뷰 저장/조회 mock 객체
+  private ReviewRepository reviewRepository;
 
   @Mock
-  private BookRepository bookRepository; // 도서 조회 mock 객체
+  private BookRepository bookRepository;
 
   @Mock
-  private UserRepository userRepository; // 유저 조회 mock 객체
+  private UserRepository userRepository;
 
   @Mock
-  private ReviewMapper reviewMapper; // 엔티티 -> DTO 변환 mock 객체
+  private ReviewMapper reviewMapper;
 
   @InjectMocks
-  private ReviewServiceImpl reviewServiceImpl; // mock 객체들이 주입될 테스트 대상
+  private ReviewServiceImpl reviewServiceImpl;
 
   private UUID bookId;
   private UUID userId;
   private UUID reviewId;
   private UUID requestUserId;
+  private UUID authorId;
 
   @BeforeEach
   void setUp() {
-    // 각 테스트에서 사용할 식별자 초기화
     bookId = UUID.randomUUID();
     userId = UUID.randomUUID();
     reviewId = UUID.randomUUID();
     requestUserId = UUID.randomUUID();
+    authorId = UUID.randomUUID();
   }
 
   @Test
   @DisplayName("리뷰 생성 - 성공")
   void createReview_success() {
-    // given
     ReviewCreateRequest reviewCreateRequest =
         new ReviewCreateRequest(bookId, userId, "테스트 리뷰", 4.5);
 
-    // Book/User 내부 필드는 안 쓰므로 mock 객체로 대체
     Book book = mock(Book.class);
     User user = mock(User.class);
     Review savedReview = mock(Review.class);
 
-    // 서비스가 최종적으로 반환할 DTO
     ReviewDto reviewDto = new ReviewDto(
         reviewId, bookId, "테스트 책", "thumb.jpg", userId, "tester",
         "테스트 리뷰", 4.5, 0, 0, false, OffsetDateTime.now(), null
     );
 
-    // 도서 조회 성공
     given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
-    // 유저 조회 성공
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
-    // 중복 리뷰 없음
     given(reviewRepository.existsByBook_IdAndUser_IdAndIsDeletedFalse(bookId, userId))
         .willReturn(false);
-    // 저장 성공
     given(reviewRepository.save(any(Review.class))).willReturn(savedReview);
-    // DTO 변환 결과
     given(reviewMapper.toDto(savedReview)).willReturn(reviewDto);
 
-    // when
     ReviewDto result = reviewServiceImpl.createReview(reviewCreateRequest);
 
-    // then
     assertThat(result.content()).isEqualTo("테스트 리뷰");
     assertThat(result.rating()).isEqualTo(4.5);
   }
@@ -112,79 +103,62 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 생성 - 존재하지 않는 도서면 예외 발생")
   void createReview_fail_whenBookNotFound() {
-    // given
     ReviewCreateRequest reviewCreateRequest =
         new ReviewCreateRequest(bookId, userId, "테스트 리뷰", 4.5);
 
-    // 도서를 찾지 못한 상황
     given(bookRepository.findById(bookId)).willReturn(Optional.empty());
 
-    // when
     Exception exception = assertThrows(
         BookNotFoundException.class,
         () -> reviewServiceImpl.createReview(reviewCreateRequest)
     );
 
-    // then
     assertThat(exception).isInstanceOf(BookNotFoundException.class);
   }
 
   @Test
   @DisplayName("리뷰 생성 - 존재하지 않는 유저면 예외 발생")
   void createReview_fail_whenUserNotFound() {
-    // given
     ReviewCreateRequest reviewCreateRequest =
         new ReviewCreateRequest(bookId, userId, "테스트 리뷰", 4.5);
 
-    // 도서는 존재
     Book book = mock(Book.class);
     given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
-
-    // 유저는 존재하지 않음
     given(userRepository.findById(userId)).willReturn(Optional.empty());
 
-    // when
     Exception exception = assertThrows(
         IllegalArgumentException.class,
         () -> reviewServiceImpl.createReview(reviewCreateRequest)
     );
 
-    // then
     assertThat(exception.getMessage()).isEqualTo("사용자를 찾을 수 없습니다.");
   }
 
   @Test
   @DisplayName("리뷰 생성 - 같은 유저가 같은 도서에 중복 리뷰 작성 시 예외 발생")
   void createReview_fail_whenDuplicateReview() {
-    // given
     ReviewCreateRequest reviewCreateRequest =
         new ReviewCreateRequest(bookId, userId, "테스트 리뷰", 4.5);
 
     Book book = mock(Book.class);
     User user = mock(User.class);
 
-    // 도서/유저는 존재
     given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
-
-    // 이미 같은 리뷰가 존재
     given(reviewRepository.existsByBook_IdAndUser_IdAndIsDeletedFalse(bookId, userId))
         .willReturn(true);
 
-    // when
     Exception exception = assertThrows(
         IllegalArgumentException.class,
         () -> reviewServiceImpl.createReview(reviewCreateRequest)
     );
 
-    // then
     assertThat(exception.getMessage()).isEqualTo("해당 도서에 작성한 리뷰가 있습니다.");
   }
 
   @Test
   @DisplayName("리뷰 상세 조회 - 성공")
   void getReview_success() {
-    // given
     Review review = mock(Review.class);
 
     ReviewDto reviewDto = new ReviewDto(
@@ -192,15 +166,11 @@ class ReviewServiceImplTest {
         "테스트 리뷰", 4.5, 1, 2, false, OffsetDateTime.now(), null
     );
 
-    // 리뷰 조회 성공
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
-    // DTO 변환
     given(reviewMapper.toDto(review)).willReturn(reviewDto);
 
-    // when
     ReviewDto result = reviewServiceImpl.getReview(reviewId, requestUserId);
 
-    // then
     assertThat(result.id()).isEqualTo(reviewId);
     assertThat(result.content()).isEqualTo("테스트 리뷰");
   }
@@ -208,23 +178,19 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 상세 조회 - 리뷰가 없으면 예외 발생")
   void getReview_fail_whenReviewNotFound() {
-    // given
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
 
-    // when
     Exception exception = assertThrows(
         IllegalArgumentException.class,
         () -> reviewServiceImpl.getReview(reviewId, requestUserId)
     );
 
-    // then
     assertThat(exception.getMessage()).isEqualTo("리뷰를 찾을 수 없습니다.");
   }
 
   @Test
   @DisplayName("리뷰 목록 조회 - 성공")
   void searchReviews_success() {
-    // given
     Review review = mock(Review.class);
 
     ReviewDto reviewDto = new ReviewDto(
@@ -232,15 +198,11 @@ class ReviewServiceImplTest {
         "테스트 리뷰", 4.5, 1, 2, false, OffsetDateTime.now(), null
     );
 
-    // 조건에 맞는 리뷰 1개 조회
     given(reviewRepository.findAllByCondition(any(ReviewSearchCondition.class)))
         .willReturn(List.of(review));
-    // 전체 개수 1개
     given(reviewRepository.countByCondition(any(ReviewSearchCondition.class))).willReturn(1L);
-    // DTO 목록 변환
     given(reviewMapper.toDtoList(any())).willReturn(List.of(reviewDto));
 
-    // when
     CursorPageResponseReviewDto result = reviewServiceImpl.searchReviews(
         requestUserId,
         userId,
@@ -253,7 +215,6 @@ class ReviewServiceImplTest {
         10
     );
 
-    // then
     assertThat(result.content()).hasSize(1);
     assertThat(result.totalElements()).isEqualTo(1);
   }
@@ -261,13 +222,11 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - 조건에 맞는 리뷰가 없으면 빈 목록 반환")
   void searchReviews_returnsEmpty_whenNoMatchedResult() {
-    // given
     given(reviewRepository.findAllByCondition(any(ReviewSearchCondition.class)))
         .willReturn(List.of());
     given(reviewRepository.countByCondition(any(ReviewSearchCondition.class))).willReturn(0L);
     given(reviewMapper.toDtoList(any())).willReturn(List.of());
 
-    // when
     CursorPageResponseReviewDto result = reviewServiceImpl.searchReviews(
         requestUserId,
         userId,
@@ -280,7 +239,6 @@ class ReviewServiceImplTest {
         10
     );
 
-    // then
     assertThat(result.content()).isEmpty();
     assertThat(result.totalElements()).isZero();
   }
@@ -288,7 +246,6 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 목록 조회 - orderBy가 createdAt 또는 rating이 아니면 예외 발생")
   void searchReviews_fail_whenInvalidOrderBy() {
-    // when
     Exception exception = assertThrows(
         IllegalArgumentException.class,
         () -> reviewServiceImpl.searchReviews(
@@ -304,17 +261,12 @@ class ReviewServiceImplTest {
         )
     );
 
-    // then
     assertThat(exception.getMessage()).isEqualTo("orderBy는 createdAt 또는 rating만 가능합니다.");
   }
 
   @Test
   @DisplayName("리뷰 수정 - 성공")
   void updateReview_success() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     User user = mock(User.class);
     Review review = mock(Review.class);
     ReviewUpdateRequest request = new ReviewUpdateRequest("수정된 리뷰", 4.5);
@@ -339,10 +291,8 @@ class ReviewServiceImplTest {
     given(user.getId()).willReturn(requestUserId);
     given(reviewMapper.toDto(review)).willReturn(reviewDto);
 
-    // when
     ReviewDto result = reviewServiceImpl.updateReview(reviewId, requestUserId, request);
 
-    // then
     verify(review).update("수정된 리뷰", 4.5);
     assertThat(result.content()).isEqualTo("수정된 리뷰");
     assertThat(result.rating()).isEqualTo(4.5);
@@ -351,11 +301,6 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 수정 - 권한 없는 사용자가 수정 시 예외 발생")
   void updateReview_fail_whenRequesterIsNotAuthor() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID authorId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     User author = mock(User.class);
     Review review = mock(Review.class);
     ReviewUpdateRequest request = new ReviewUpdateRequest("수정 시도", 4.5);
@@ -364,9 +309,8 @@ class ReviewServiceImplTest {
     given(review.getUser()).willReturn(author);
     given(author.getId()).willReturn(authorId);
 
-    // when & then
     assertThatThrownBy(() -> reviewServiceImpl.updateReview(reviewId, requestUserId, request))
-        .isInstanceOf(ReviewUpdateForbidden.class)
+        .isInstanceOf(ReviewUpdateForbiddenException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.REVIEW_UPDATE_FORBIDDEN);
 
@@ -376,10 +320,6 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 논리 삭제 - 성공")
   void deleteReview_success() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     User author = mock(User.class);
     Review review = mock(Review.class);
 
@@ -387,23 +327,16 @@ class ReviewServiceImplTest {
     given(review.getUser()).willReturn(author);
     given(author.getId()).willReturn(requestUserId);
 
-    // when
     reviewServiceImpl.deleteReview(reviewId, requestUserId);
 
-    // then
     verify(review).softDelete();
   }
 
   @Test
   @DisplayName("리뷰 논리 삭제 - 리뷰가 없으면 예외 발생")
   void deleteReview_fail_whenReviewNotFound() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
 
-    // when & then
     assertThatThrownBy(() -> reviewServiceImpl.deleteReview(reviewId, requestUserId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("리뷰를 찾을 수 없습니다.");
@@ -412,11 +345,6 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 논리 삭제 - 권한 없는 사용자가 삭제 시 예외 발생")
   void deleteReview_fail_whenRequesterIsNotAuthor() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID authorId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     User author = mock(User.class);
     Review review = mock(Review.class);
 
@@ -424,9 +352,8 @@ class ReviewServiceImplTest {
     given(review.getUser()).willReturn(author);
     given(author.getId()).willReturn(authorId);
 
-    // when & then
     assertThatThrownBy(() -> reviewServiceImpl.deleteReview(reviewId, requestUserId))
-        .isInstanceOf(ReviewUpdateForbidden.class)
+        .isInstanceOf(ReviewUpdateForbiddenException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.REVIEW_UPDATE_FORBIDDEN);
 
@@ -436,10 +363,6 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 물리 삭제 - 성공")
   void hardDeleteReview_success() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     User author = mock(User.class);
     Review review = mock(Review.class);
 
@@ -448,23 +371,16 @@ class ReviewServiceImplTest {
     given(author.getId()).willReturn(requestUserId);
     given(review.isDeleted()).willReturn(true);
 
-    // when
     reviewServiceImpl.hardDeleteReview(reviewId, requestUserId);
 
-    // then
     verify(reviewRepository).delete(review);
   }
 
   @Test
   @DisplayName("리뷰 물리 삭제 - 리뷰가 없으면 예외 발생")
   void hardDeleteReview_fail_whenReviewNotFound() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
 
-    // when & then
     assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("리뷰를 찾을 수 없습니다.");
@@ -473,11 +389,6 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 물리 삭제 - 권한 없는 사용자가 삭제 시 예외 발생")
   void hardDeleteReview_fail_whenRequesterIsNotAuthor() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID authorId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     User author = mock(User.class);
     Review review = mock(Review.class);
 
@@ -485,9 +396,8 @@ class ReviewServiceImplTest {
     given(review.getUser()).willReturn(author);
     given(author.getId()).willReturn(authorId);
 
-    // when & then
     assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
-        .isInstanceOf(ReviewUpdateForbidden.class)
+        .isInstanceOf(ReviewUpdateForbiddenException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.REVIEW_UPDATE_FORBIDDEN);
 
@@ -497,10 +407,6 @@ class ReviewServiceImplTest {
   @Test
   @DisplayName("리뷰 물리 삭제 - 논리 삭제되지 않은 리뷰면 예외 발생")
   void hardDeleteReview_fail_whenReviewIsNotSoftDeleted() {
-    // given
-    UUID reviewId = UUID.randomUUID();
-    UUID requestUserId = UUID.randomUUID();
-
     User author = mock(User.class);
     Review review = mock(Review.class);
 
@@ -509,7 +415,6 @@ class ReviewServiceImplTest {
     given(author.getId()).willReturn(requestUserId);
     given(review.isDeleted()).willReturn(false);
 
-    // when & then
     assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("논리 삭제된 리뷰만 물리 삭제할 수 있습니다.");

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -16,7 +16,11 @@ import com.team01.deokhugam.book.repository.BookRepository;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.ErrorCode;
 import com.team01.deokhugam.global.exception.book.BookNotFoundException;
+import com.team01.deokhugam.global.exception.review.ReviewAlreadyExistsException;
+import com.team01.deokhugam.global.exception.review.ReviewNotFoundException;
+import com.team01.deokhugam.global.exception.review.ReviewNotSoftDeletedException;
 import com.team01.deokhugam.global.exception.review.ReviewUpdateForbiddenException;
+import com.team01.deokhugam.global.exception.user.UserNotFoundException;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
@@ -127,7 +131,7 @@ class ReviewServiceImplTest {
     given(userRepository.findById(userId)).willReturn(Optional.empty());
 
     Exception exception = assertThrows(
-        IllegalArgumentException.class,
+        UserNotFoundException.class,
         () -> reviewServiceImpl.createReview(reviewCreateRequest)
     );
 
@@ -149,7 +153,7 @@ class ReviewServiceImplTest {
         .willReturn(true);
 
     Exception exception = assertThrows(
-        IllegalArgumentException.class,
+        ReviewAlreadyExistsException.class,
         () -> reviewServiceImpl.createReview(reviewCreateRequest)
     );
 
@@ -181,7 +185,7 @@ class ReviewServiceImplTest {
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
 
     Exception exception = assertThrows(
-        IllegalArgumentException.class,
+        ReviewNotFoundException.class,
         () -> reviewServiceImpl.getReview(reviewId, requestUserId)
     );
 
@@ -338,7 +342,7 @@ class ReviewServiceImplTest {
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
 
     assertThatThrownBy(() -> reviewServiceImpl.deleteReview(reviewId, requestUserId))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(ReviewNotFoundException.class)
         .hasMessage("리뷰를 찾을 수 없습니다.");
   }
 
@@ -382,7 +386,7 @@ class ReviewServiceImplTest {
     given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
 
     assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(ReviewNotFoundException.class)
         .hasMessage("리뷰를 찾을 수 없습니다.");
   }
 
@@ -416,7 +420,7 @@ class ReviewServiceImplTest {
     given(review.isDeleted()).willReturn(false);
 
     assertThatThrownBy(() -> reviewServiceImpl.hardDeleteReview(reviewId, requestUserId))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(ReviewNotSoftDeletedException.class)
         .hasMessage("논리 삭제된 리뷰만 물리 삭제할 수 있습니다.");
 
     verify(reviewRepository, never()).delete(any(Review.class));


### PR DESCRIPTION
## 📌 관련 이슈

- closes #46 

## 📝 작업 내용

- 리뷰 논리 삭제 기능 구현
- 리뷰 물리 삭제 기능 구현
- 삭제 권한 검증 추가
- 논리 삭제된 리뷰만 물리 삭제 가능하도록 검증 추가
- 삭제 관련 서비스 테스트 작성
- 삭제 관련 컨트롤러 테스트 작성

## 💡 변경 사항

- DELETE /api/reviews/{reviewId} 추가
- DELETE /api/reviews/{reviewId}/hard 추가
- 논리 삭제는 softDelete() 적용
- 물리 삭제는 논리 삭제된 리뷰만 delete() 가능

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리뷰 삭제 엔드포인트 2종 추가: 논리적 삭제와 논리 삭제된 후의 물리적 삭제(성공 시 204 반환)
* **권한/행동 제한**
  * 삭제는 요청자 본인만 가능하며 물리적 삭제는 먼저 논리 삭제되어야 함
* **검증/오류 개선**
  * 리뷰 내용·길이·평점 검증 강화 및 중복/미존재/삭제 상태 관련 명확한 오류 응답 추가
* **테스트**
  * 삭제 흐름·경계값·오류 처리에 대한 단위 및 컨트롤러 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->