### PR TITLE
chore: CD 파이프라인 구축 및 application.yaml 수정

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,7 @@ src/main/resources/project-deokhugam-fe-v2-2.0.3/
 # Security - 환경 변수 / 시크릿 (이미지에 절대 포함 금지)
 .env
 .env.*
+*.pem
 !.env.example
 
 # Docker 관련 파일 자체 (빌드 컨텍스트에 불필요)

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@
 # !!! 실제 값 들어간 상태로 형상관리 되지 않도록 주의할 것 !!!
 
 # Spring 프로필
-SPRING_PROFILES_ACTIVE=dev
+# SPRING_PROFILES_ACTIVE=dev
+#  - docker compose 실행 시: docker-compose.yml이 dev로 덮어씀
+#  - docker run 이미지 직접 실행 시: Dockerfile이 prod로 고정
 SERVER_PORT=8080
 
 # Docker Compose PostgreSQL (컨테이너용)

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,7 @@
 # !!! 실제 값 들어간 상태로 형상관리 되지 않도록 주의할 것 !!!
 
 # Spring 프로필
-# SPRING_PROFILES_ACTIVE=dev
-#  - docker compose 실행 시: docker-compose.yml이 dev로 덮어씀
-#  - docker run 이미지 직접 실행 시: Dockerfile이 prod로 고정
+SPRING_PROFILES_ACTIVE=dev
 SERVER_PORT=8080
 
 # Docker Compose PostgreSQL (컨테이너용)
@@ -41,3 +39,6 @@ STORAGE_LOCAL_ROOT_PATH=.deokhugam/storage
 # 네이버 API
 NAVER_CLIENT_ID=예시_데이터
 NAVER_CLIENT_SECRET=예시_데이터
+
+# OCR API
+OCR_API_KEY=예시_데이터

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,169 @@
+# CD 워크플로우 이름
+name: CD
+
+# 트리거 조건: main 브랜치에 코드가 푸시될 때 실행
+on:
+  push:
+    branches: [ main ]
+
+# 이 워크플로우가 리포지토리 소스코드를 읽기만 할 수 있도록 제한
+permissions:
+  contents: read # 읽기만 가능
+
+jobs:
+  # Docker 이미지 빌드 & Public ECR 푸시
+  build-and-push:
+    name: Build & Push to Public ECR
+    runs-on: ubuntu-latest
+
+    # 다음 Job(deploy)에 이미지 URI를 전달하기 위한 출력
+    outputs:
+      image-uri: ${{ steps.image.outputs.uri }}
+
+    steps:
+      # 1) 소스코드 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v4 # 현재 repo의 소스코드를 Runner 작업 디렉터리로 복사
+
+      # 2) AWS 자격 증명 설정
+      - name: Configure AWS credentials (Public ECR)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          # Public ECR API 엔드포인트가 us-east-1 리전에만 존재하므로 인증도 us-east-1로 진행
+          aws-region: us-east-1
+
+      # 3) Public ECR 로그인
+      - name: Login to Amazon Public ECR
+        id: login-ecr
+        # ECR 레지스트리에 Docker 클라이언트를 로그인
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public # Public ECR 로그인
+
+      # 4) Docker 이미지 빌드 & 푸시
+      # - 멀티 플랫폼 옵션 사용 X (Runner와 ECS 모두 x86_64이므로 불필요)
+      # - 태그: latest + GitHub 커밋 해시(github.sha)
+      - name: Build & push Docker image
+        id: image
+        env:
+          ECR_URI: ${{ secrets.ECR_REPOSITORY_URI }}
+          SHA: ${{ github.sha }} # 커밋 해시
+        run: |
+          docker build \
+            -t "$ECR_URI:latest" \
+            -t "$ECR_URI:$SHA" \
+            .
+          docker push "$ECR_URI:latest"
+          docker push "$ECR_URI:$SHA"
+          echo "uri=$ECR_URI:$SHA" >> "$GITHUB_OUTPUT"
+        # 다음 Job에서 사용할 수 있도록 SHA 태그가 붙은 URI를 출력
+
+  # ECS 서비스 업데이트 (배포)
+  deploy:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+    needs: build-and-push   # 해당 job이 끝나야 배포 시작
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 1) AWS 자격 증명 설정 (ECS용)
+      - name: Configure AWS credentials (ECS)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # 2) 기존 태스크 정의 다운로드
+      # describe-task-definition 결과에는 register-task-definition이 거부하는
+      # read-only 필드들이 포함되어 있으므로 jq로 제거
+      - name: Download current task definition
+        # --query taskDefinition: API 응답에서 taskDefinition 객체만 추출
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ vars.ECS_TASK_DEFINITION }} \
+            --query taskDefinition \
+            | jq 'del(
+              .taskDefinitionArn,
+              .revision,
+              .status,
+              .requiresAttributes,
+              .compatibilities,
+              .registeredAt,
+              .registeredBy,
+              .deregisteredAt
+            )' > task-definition.json
+
+      # 3) 새 이미지 URI를 태스크 정의에 주입
+      # amazon-ecs-render-task-definition
+      #  - task-definition.json 안에서 container-name이 "deokhugam-app"인
+      #    컨테이너 정의를 찾아서 image 필드를 새 URI로 교체
+      #    수정된 JSON 파일의 경로를 outputs.task-definition으로 출력
+      - name: Render new image into task definition
+        id: render
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: deokhugam-app
+          image: ${{ needs.build-and-push.outputs.image-uri }}
+
+      # 4) 새 태스크 정의를 AWS에 등록
+      - name: Register new task definition revision
+        id: register
+        # register-task-definition
+        #  - 수정된 JSON을 AWS에 업로드하여 새 리비전(버전)을 생성
+        # --cli-input-json file://${{ steps.render.outputs.task-definition }}
+        #  - 랜더링된 테스크 정의 파일을 입력으로 전달
+        # --query 'taskDefinition.taskDefinitionArn'
+        #  - 등록된 새 리비전의 ARN만 추출
+        # echo "arn=$NEW_TD_ARN" >> "$GITHUB_OUTPUT"
+        #  - 다음 스텝에서 이 ARN을 참조하기 위해 출력
+        run: |
+          NEW_TD_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file://${{ steps.render.outputs.task-definition }} \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          echo "arn=$NEW_TD_ARN" >> "$GITHUB_OUTPUT"
+
+      # 5) 기존에 구동 중인 서비스 중단 (프리티어 리소스 확보)
+      # 기존 컨테이너를 먼저 내린 후 새 컨테이너를 올리는 전략
+      - name: Stop running service (free tier capacity)
+        # desired-count=0
+        #  - 실행 중인 테스크 수를 0으로 만든다.
+        #  - ECS가 실행 중인 컨테이너를 graceful shutdown한다.
+        # aws ecs wait services-stable
+        #  - 서비스가 안정 상태(desired=running=0)가 될 때까지 폴링하며 대기
+        #  - 컨테이너가 완전히 종료된 것을 보장한 후 다음 단계 진행
+        run: |
+          aws ecs update-service \
+            --cluster ${{ vars.ECS_CLUSTER }} \
+            --service ${{ vars.ECS_SERVICE }} \
+            --desired-count 0
+          aws ecs wait services-stable \
+            --cluster ${{ vars.ECS_CLUSTER }} \
+            --services ${{ vars.ECS_SERVICE }}
+
+      # 6) 새 태스크 정의로 ECS 서비스 업데이트 + 재시작
+      # desired-count=1로 다시 올려 새 이미지로 컨테이너 기동
+      - name: Update ECS service with new task definition
+        # --task-definition ${{ steps.register.outputs.arn }}
+        #  - 새 리비전의 ARN을 서비스에 적용
+        #  - 이 서비스는 새 이미지가 포함된 테스크 정의를 사용
+        # --desired-count 1
+        #  - 테스크 수를 다시 1로 올려 새 이미지로 컨테이너 1개를 작동
+        # aws ecs wait services-stable
+        #  - 새 컨테이너가 RUNNING 상태가 될 때까지 대기
+        #  - 헬스체크 통과까지 포함하여 서비스가 안정화되면 완료
+        run: |
+          aws ecs update-service \
+            --cluster ${{ vars.ECS_CLUSTER }} \
+            --service ${{ vars.ECS_SERVICE }} \
+            --task-definition ${{ steps.register.outputs.arn }} \
+            --desired-count 1
+          aws ecs wait services-stable \
+            --cluster ${{ vars.ECS_CLUSTER }} \
+            --services ${{ vars.ECS_SERVICE }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: cd-${{ github.ref }} # 같은 브랜치의 중복 배포만
+  # 같은 group에 이미 실행 중인 워크플로우가 있을 때
+  # 진행 중인 작업은 끝까지 수행하고, 새 작업은 대기열에 추가
+  cancel-in-progress: false # 순차 처리
+
 # 이 워크플로우가 리포지토리 소스코드를 읽기만 할 수 있도록 제한
 permissions:
   contents: read # 읽기만 가능

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 .env
 .env.*
 *.env
+*.pem
 !.env.example
 
 # 필요시 추가할 것

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,11 @@ FROM ${IMAGE}
 # 앱 실행 디렉토리 지정
 WORKDIR /app
 
+# 포트를 빌드 인자로 선언 (기본값 8080)
+ARG SERVER_PORT=8080
+# 런타임에서도 참조 가능하도록 ENV로 전파
+ENV SERVER_PORT=${SERVER_PORT}
+
 # 애플리케이션 실행용 non-root 사용자 생성
 RUN adduser -D appuser && chown -R appuser:appuser /app
 USER appuser
@@ -87,7 +92,9 @@ USER appuser
 # 빌드 스테이지에서 생성한 JAR 파일만 복사
 COPY --from=builder /app/build/libs/*.jar ./app.jar
 
-#   wget -qO- http://localhost:8080/actuator/health
+EXPOSE ${SERVER_PORT}
+
+#   wget -qO- http://localhost:${SERVER_PORT}/actuator/health
 #     - wget: HTTP 요청을 보내는 CLI 도구 (alpine 이미지에 기본 포함)
 #     - -q: quiet 모드 (진행 상황 출력 안 함)
 #     - -O-: 응답 결과를 stdout으로 출력 (파일 저장 안 함)
@@ -96,23 +103,25 @@ COPY --from=builder /app/build/libs/*.jar ./app.jar
 #   || exit 1
 #     - wget이 실패하면(HTTP 에러 또는 연결 불가) exit code 1을 반환
 #     - exit 0 = healthy, exit 1 = unhealthy
-# TODO: Linux에서 1024 미만 포트는 root만 바인딩할 수 있다 -> 배포할 때 참고할 것
-# FIXME: 배포할 때 포트 번호에 따라서 8080 하드코딩 값 수정 필요
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-  CMD wget -qO- http://localhost:8080/actuator/health || exit 1
+  CMD wget -qO- http://localhost:${SERVER_PORT}/actuator/health || exit 1
 
-# EXPOSE 80
 
-## JVM 옵션을 환경 변수로 설정 - JVM_OPTS: 기본값은 빈 문자열로 정의
-#  - JVM_OPTS: JVM(Java Virtual Machine) 실행 옵션을 환경 변수로 설정
-#    - 실행 시 오버라이드 할 수 있음
-#    - 예: docker run -e JVM_OPTS="-Xmx512m -Xms256m"
-#      - -Xmx512m: 최대 힙 메모리 512MB
-#      - -Xms256m: 초기 힙 메모리 256MB
-#      ->  컨테이너 환경에서 메모리 제한에 맞게 JVM 옵션 조정
-ENV JVM_OPTS=""
+# JVM Configuration (프리티어 고려)
+# -Xmx256m : 최대 힙 메모리를 256MB로 제한
+#  - JVM이 이 이상의 힙 메모리를 할당하지 않으며, 초과 시 OutOfMemoryError가 발생
+# -Xms128m : 초기 힙 메모리를 128MB로 설정
+#  - JVM 시작 시 OS로부터 128MB를 미리 확보하므로, 런타임 중 힙 확장에 따른 지연을 줄여줌
+# -XX:MaxMetaspaceSize=128m : 메타스페이스 최대 크기를 128MB로 제한
+#  - 메타스페이스는 클래스 메타데이터(클래스 정의, 메서드 정보 등)를 저장하는 네이티브 메모리 영역
+#  - 기본값은 무제한. 제한 이유 - 클래스 로딩 누수를 조기에 감지하거나 메모리 사용량을 통제하려는 목적
+# -XX:+UseSerialGC : Serial GC를 사용
+#  - 단일 스레드로 GC를 수행하는 가장 단순한 컬렉터
+#  - GC 중 모든 애플리케이션 스레드가 멈추는(STW) 단점 존재
+#  - GC 스레드 자체의 오버헤드가 거의 없어 메모리가 적고 CPU 코어가 제한된 환경(컨테이너, 임베디드 등)에 적합
+ENV JVM_OPTS="-Xmx256m -Xms128m -XX:MaxMetaspaceSize=128m -XX:+UseSerialGC"
 
-ENV SPRING_PROFILES_ACTIVE=dev
+ENV SPRING_PROFILES_ACTIVE=prod
 
 ## 애플리케이션 실행 명령어를 설정 - 이때 환경변수로 정의한 프로젝트 정보를 활용
 # ENTRYPOINT: 컨테이너가 시작될 때 실행할 명령어를 지정

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@
 # 데이터 포함 삭제: docker compose down -v
 # 볼륨 확인: docker volume ls
 
+# 용도: 로컬 개발 환경 전용 (dev 프로필 고정)
+# 운영 배포는 CD 파이프라인(ECS/EC2 등)에서 Dockerfile 이미지 직접 실행
+
 services:
   deokhugam:
     build:
@@ -10,7 +13,7 @@ services:
       # dockerfile - 사용할 Dockerfile의 경로 (context 경로를 기준으로 한 상대 경로)
       dockerfile: Dockerfile
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      SPRING_PROFILES_ACTIVE: dev
       SERVER_PORT: ${SERVER_PORT}
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}

--- a/src/main/java/com/team01/deokhugam/book/entity/Book.java
+++ b/src/main/java/com/team01/deokhugam/book/entity/Book.java
@@ -3,7 +3,6 @@ package com.team01.deokhugam.book.entity;
 import com.team01.deokhugam.global.entity.BaseRemovableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -16,20 +15,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Book extends BaseRemovableEntity {
+
   @Column(name = "title", length = 255, nullable = false)
   private String title;
 
   @Column(name = "author", length = 100, nullable = false)
   private String author;
 
-  @Column(name = "description", nullable = false)
-  @Lob
+  @Column(name = "description", nullable = false, columnDefinition = "TEXT")
   private String description;
 
   @Column(name = "publisher", length = 100, nullable = false)
   private String publisher;
 
-  @Column(name = "published_date" , nullable = false)
+  @Column(name = "published_date", nullable = false)
   private LocalDate publishedDate;
 
   @Column(name = "isbn", unique = true, updatable = false, length = 20)
@@ -45,7 +44,8 @@ public class Book extends BaseRemovableEntity {
   private double rating = 0.0;
 
   @Builder
-  public Book(String title, String author, String description, String publisher, LocalDate publishedDate, String isbn, String thumbnailUrl) {
+  public Book(String title, String author, String description, String publisher,
+      LocalDate publishedDate, String isbn, String thumbnailUrl) {
     this.title = title;
     this.author = author;
     this.description = description;
@@ -55,27 +55,27 @@ public class Book extends BaseRemovableEntity {
     // reviewCount, rating, isDeleted는 생성 시에는 필요없이 default로 들어가야해서 없음
   }
 
-  public void addThumbnail(String thumbnailUrl){
+  public void addThumbnail(String thumbnailUrl) {
     this.thumbnailUrl = thumbnailUrl;
   }
 
-  public void updateTitle(String newTitle){
+  public void updateTitle(String newTitle) {
     this.title = newTitle;
   }
 
-  public void updateAuthor(String newAuthor){
+  public void updateAuthor(String newAuthor) {
     this.author = newAuthor;
   }
 
-  public void updateDescription(String newDescription){
+  public void updateDescription(String newDescription) {
     this.description = newDescription;
   }
 
-  public void updatePublisher(String newPublisher){
+  public void updatePublisher(String newPublisher) {
     this.publisher = newPublisher;
   }
 
-  public void updatePublishedDate(LocalDate newPublishedDate){
+  public void updatePublishedDate(LocalDate newPublishedDate) {
     this.publishedDate = newPublishedDate;
   }
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -3,9 +3,12 @@ spring:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
+  sql:
+    init:
+      mode: always
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,12 +1,11 @@
-server:
-  port: 8080
-
 spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
+    hibernate:
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,12 +1,11 @@
-server:
-  port: 80
-
 spring:
   datasource:
     url: ${RDS_SPRING_DATASOURCE_URL}
     username: ${RDS_SPRING_DATASOURCE_USERNAME}
     password: ${RDS_SPRING_DATASOURCE_PASSWORD}
   jpa:
+    hibernate:
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: false
@@ -20,6 +19,10 @@ logging:
     org.hibernate.SQL: info
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
   endpoint:
     health:
       show-details: never

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
+server:
+  port: ${SERVER_PORT:8080}
+
 spring:
   # profile을 .env 값 참조하여 결정
   profiles:
@@ -12,9 +15,10 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create # 기존 테이블을 삭제(DROP)하고 엔티티를 기반으로 새 테이블을 생성
+      ddl-auto: validate
       # validate : 엔티티와 실제 DB 테이블이 일치하는지만 검사함. 다를 경우 예외를 발생시키고 실행을 중단
       # update : 변경된 엔티티에 맞춰 테이블 스키마를 업데이트함. 단, 컬럼 추가는 되지만 삭제나 타입 변경은 반영되지 않음
+      # create : 기존 테이블을 삭제(DROP)하고 엔티티를 기반으로 새 테이블을 생성
     open-in-view: false
   config:
     import: optional:file:.env[.properties]
@@ -28,7 +32,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,loggers
+        include: health, info, metrics, loggers
   endpoint:
     health:
       show-details: always

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,13 +1,9 @@
--- ==========================================
--- 1. 핵심 도메인 테이블
--- ==========================================
-
-CREATE TABLE users
+CREATE TABLE IF NOT EXISTS users
 (
     id         UUID PRIMARY KEY,
     email      VARCHAR(255) NOT NULL UNIQUE,
     nickname   VARCHAR(20)  NOT NULL,
-    password   VARCHAR(255) NOT NULL,
+    password   VARCHAR(100) NOT NULL,
 
     is_deleted BOOLEAN      NOT NULL DEFAULT FALSE,
     deleted_at TIMESTAMPTZ,
@@ -15,47 +11,53 @@ CREATE TABLE users
     updated_at TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE books
+CREATE TABLE IF NOT EXISTS books
 (
     id             UUID PRIMARY KEY,
-    title          VARCHAR(255)  NOT NULL,
-    author         VARCHAR(100)  NOT NULL,
-    description    TEXT          NOT NULL,
-    publisher      VARCHAR(100)  NOT NULL,
-    published_date DATE          NOT NULL,
+    title          VARCHAR(255)     NOT NULL,
+    author         VARCHAR(100)     NOT NULL,
+    description    TEXT             NOT NULL,
+    publisher      VARCHAR(100)     NOT NULL,
+    published_date DATE             NOT NULL,
     isbn           VARCHAR(20) UNIQUE,
     thumbnail_url  VARCHAR(255),
-    review_count   INTEGER       NOT NULL DEFAULT 0 CHECK (review_count >= 0),
-    rating         NUMERIC(3, 2) NOT NULL DEFAULT 0.00 CHECK (rating >= 0.0 AND rating <= 5.0),
+    review_count   INTEGER          NOT NULL DEFAULT 0 CHECK (review_count >= 0),
+    rating         DOUBLE PRECISION NOT NULL DEFAULT 0.0 CHECK (rating >= 0.0 AND rating <= 5.0),
 
 
-    is_deleted     BOOLEAN       NOT NULL DEFAULT FALSE,
-    deleted_at    TIMESTAMPTZ,
-    created_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP
+    is_deleted     BOOLEAN          NOT NULL DEFAULT FALSE,
+    deleted_at     TIMESTAMPTZ,
+    created_at     TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE reviews
+CREATE TABLE IF NOT EXISTS reviews
 (
     id            UUID PRIMARY KEY,
-    book_id       UUID          NOT NULL,
-    user_id       UUID          NOT NULL,
-    content       VARCHAR(1000) NOT NULL,
-    rating        NUMERIC(3, 2) NOT NULL CHECK (rating >= 1.0 AND rating <= 5.0),
-    liked_count   INTEGER       NOT NULL DEFAULT 0 CHECK (liked_count >= 0),
-    comment_count INTEGER       NOT NULL DEFAULT 0 CHECK (comment_count >= 0),
+    book_id       UUID             NOT NULL,
+    user_id       UUID             NOT NULL,
+    content       VARCHAR(1000)    NOT NULL,
+    rating        DOUBLE PRECISION NOT NULL CHECK (rating >= 1.0 AND rating <= 5.0),
+    like_count    INTEGER          NOT NULL DEFAULT 0 CHECK (like_count >= 0),
+    comment_count INTEGER          NOT NULL DEFAULT 0 CHECK (comment_count >= 0),
+    version       BIGINT           NOT NULL DEFAULT 0,
 
-    is_deleted    BOOLEAN       NOT NULL DEFAULT FALSE,
+    is_deleted    BOOLEAN          NOT NULL DEFAULT FALSE,
     deleted_at    TIMESTAMPTZ,
-    created_at    TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at    TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_reviews_books FOREIGN KEY (book_id) REFERENCES books (id) ON DELETE CASCADE,
     CONSTRAINT fk_reviews_users FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT uk_reviews_book_user UNIQUE (book_id, user_id)
 );
 
-CREATE TABLE comments
+CREATE INDEX IF NOT EXISTS idx_reviews_book_id ON reviews (book_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_user_id ON reviews (user_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_created_at ON reviews (created_at);
+CREATE INDEX IF NOT EXISTS idx_reviews_rating_created_at ON reviews (rating, created_at);
+
+CREATE TABLE IF NOT EXISTS comments
 (
     id         UUID PRIMARY KEY,
     review_id  UUID         NOT NULL,
@@ -71,26 +73,28 @@ CREATE TABLE comments
     CONSTRAINT fk_comments_users FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
-CREATE TABLE notifications
-(
-    id         UUID PRIMARY KEY,
-    review_id  UUID         NOT NULL,
-    user_id    UUID         NOT NULL,
-    content    VARCHAR(255) NOT NULL,
-    is_read    BOOLEAN      NOT NULL DEFAULT FALSE,
+CREATE INDEX IF NOT EXISTS idx_comment_review_created_at_id ON comments (review_id, created_at, id);
 
-    created_at TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE IF NOT EXISTS notifications
+(
+    id           UUID PRIMARY KEY,
+    review_id    UUID         NOT NULL,
+    user_id      UUID         NOT NULL,
+    content      VARCHAR(255) NOT NULL,
+    is_read      BOOLEAN      NOT NULL DEFAULT FALSE,
+    confirmed_at TIMESTAMPTZ,
+
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_notifications_reviews FOREIGN KEY (review_id) REFERENCES reviews (id) ON DELETE CASCADE,
     CONSTRAINT fk_notifications_users FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
--- ==========================================
--- 2. 좋아요 여부 기록
--- ==========================================
+CREATE INDEX IF NOT EXISTS idx_notifications_user_read ON notifications (user_id, is_read);
+CREATE INDEX IF NOT EXISTS idx_notifications_review_id ON notifications (review_id);
 
-CREATE TABLE liked_reviews
+CREATE TABLE IF NOT EXISTS liked_reviews
 (
     id         UUID PRIMARY KEY,
     review_id  UUID        NOT NULL,
@@ -104,31 +108,29 @@ CREATE TABLE liked_reviews
     CONSTRAINT uk_liked_reviews_user_review UNIQUE (review_id, user_id) -- 1인 1리뷰 1좋아요 보장 💡
 );
 
--- ==========================================
--- 3. 통계 및 랭킹 테이블
--- ==========================================
-
-CREATE TABLE popular_books
+CREATE TABLE IF NOT EXISTS popular_books
 (
     id              UUID PRIMARY KEY,
-    book_id         UUID           NOT NULL,
-    period_type     VARCHAR(20)    NOT NULL CHECK (period_type IN
-                                                   ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY',
-                                                    'ALL_TIME')),
-    calculated_date DATE           NOT NULL, -- 랭킹 산정 기준일 (시간은 필요 없으므로 DATE)
-    rank            INTEGER        NOT NULL CHECK (rank > 0),
-    score           NUMERIC(10, 2) NOT NULL CHECK (score >= 0),
-    rating          NUMERIC(3, 2)  NOT NULL CHECK (rating >= 0.0 AND rating <= 5.0),
-    review_count    INTEGER        NOT NULL DEFAULT 0 CHECK (review_count >= 0),
+    book_id         UUID             NOT NULL,
+    period_type     VARCHAR(20)      NOT NULL CHECK (period_type IN
+                                                     ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY',
+                                                      'ALL_TIME')),
+    calculated_date DATE             NOT NULL, -- 랭킹 산정 기준일 (시간은 필요 없으므로 DATE)
+    rank            INTEGER          NOT NULL CHECK (rank > 0),
+    score           DOUBLE PRECISION NOT NULL CHECK (score >= 0),
+    rating          DOUBLE PRECISION NOT NULL CHECK (rating >= 0.0 AND rating <= 5.0),
+    review_count    INTEGER          NOT NULL DEFAULT 0 CHECK (review_count >= 0),
 
-    created_at      TIMESTAMPTZ    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at      TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_popular_books_book FOREIGN KEY (book_id) REFERENCES books (id) ON DELETE CASCADE,
     CONSTRAINT uk_popular_books_period_rank UNIQUE (period_type, calculated_date, rank),
     CONSTRAINT uk_popular_books_period_book UNIQUE (period_type, calculated_date, book_id)
 );
 
-CREATE TABLE popular_reviews
+CREATE INDEX IF NOT EXISTS idx_popular_books_book_id ON popular_books (book_id);
+
+CREATE TABLE IF NOT EXISTS popular_reviews
 (
     id              UUID PRIMARY KEY,
     review_id       UUID           NOT NULL,
@@ -148,18 +150,20 @@ CREATE TABLE popular_reviews
     CONSTRAINT uk_popular_reviews_period_review UNIQUE (period_type, calculated_date, review_id)
 );
 
-CREATE TABLE power_users
+CREATE TABLE IF NOT EXISTS power_users
 (
-    id              UUID PRIMARY KEY,
-    user_id         UUID           NOT NULL,
-    period_type     VARCHAR(20)    NOT NULL CHECK (period_type IN
-                                                   ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY',
-                                                    'ALL_TIME')),
-    calculated_date DATE           NOT NULL,
-    rank            INTEGER        NOT NULL CHECK (rank > 0),
-    score           NUMERIC(10, 2) NOT NULL CHECK (score >= 0),
+    id               UUID PRIMARY KEY,
+    user_id          UUID             NOT NULL,
+    period_type      VARCHAR(20)      NOT NULL CHECK (period_type IN
+                                                      ('DAILY', 'WEEKLY', 'MONTHLY', 'ALL_TIME')),
+    calculated_date  TIMESTAMPTZ      NOT NULL,
+    rank             BIGINT           NOT NULL CHECK (rank > 0),
+    score            DOUBLE PRECISION NOT NULL CHECK (score >= 0),
+    review_score_sum DOUBLE PRECISION NOT NULL DEFAULT 0,
+    like_count       BIGINT           NOT NULL DEFAULT 0 CHECK (like_count >= 0),
+    comment_count    BIGINT           NOT NULL DEFAULT 0 CHECK (comment_count >= 0),
 
-    created_at      TIMESTAMPTZ    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at       TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_power_users_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT uk_power_users_period_rank UNIQUE (period_type, calculated_date, rank),


### PR DESCRIPTION
## 📌 관련 이슈

- closes #151 

## 📝 작업 내용

- GitHub Actions 기반 CD 파이프라인을 추가하여 `main` 브랜치 푸시 시 AWS 환경으로 자동 배포되도록 구성
- 운영(prod) / 로컬(dev) 실행 환경을 분리하고 Dockerfile·docker-compose 구성을 정비
- 운영 배포 시 스키마 불일치로 인한 장애를 막기 위해 `ddl-auto`를 `validate`로 전환하고 `schema.sql`을 실제 엔티티와 일치하도록 정리  

## 💡 변경 사항

- **CD 워크플로우 추가** (`.github/workflows/cd.yml`)
  - `main` 푸시 시 ECR 이미지 빌드·푸시 -> ECS 서비스 롤링 배포
  - 같은 브랜치 중복 배포 방지를 위한 `concurrency` 그룹 설정 (`cancel-in-progress: false`로 순차 처리)
  - 최소 권한 원칙에 따라 `permissions: contents: read` 부여
- **운영 이미지 구성 정비**
  - 운영용 `Dockerfile` 멀티스테이지 빌드로 정리, `.dockerignore` 규칙 보강
  - `docker-compose.yml`은 로컬 dev 전용으로 분리
- **프로필/포트 설정 정리**
  - `application.yaml` · `application-dev.yaml` · `application-prod.yaml` 분리 및 포트 설정 정돈
- **DB 스키마 정합성 작업**
  - dev 프로필 `ddl-auto`: `create` -> `validate`, `spring.sql.init.mode=always` 추가
  - `schema.sql`: `CREATE TABLE IF NOT EXISTS` 적용, `rating`/`score` 등 숫자 타입을 `DOUBLE PRECISION`으로 통일, 주요 조회 인덱스 추가, `reviews.like_count`·`version`, `notifications.confirmed_at`, `power_users` 구조를 최신 엔티티에 맞춤
  - `Book` 엔티티: `@Lob` 제거 후 `columnDefinition = "TEXT"`로 schema.sql과 일치
- **기타**
  - `.gitignore`에 보안 관련 규칙 추가, `.env.example`에 `OCR_API_KEY` 명시

## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 자동화된 CI/CD 파이프라인 추가: 메인 브랜치 푸시 시 AWS ECS에 자동 배포

* **개선 사항**
  * 서버 포트 설정 유연성 향상
  * 개발 및 프로덕션 환경 설정 분리 강화
  * JVM 런타임 옵션 최적화

* **보안 강화**
  * 개인키/인증서 파일 자동 제외 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->