### PR TITLE
feat: 파워유저 컨트롤러 구현

### DIFF
--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
@@ -3,6 +3,7 @@ package com.team01.deokhugam.batch.service;
 import com.team01.deokhugam.batch.common.DashboardPeriod;
 import com.team01.deokhugam.dashboard.poweruser.entity.PowerUser;
 import com.team01.deokhugam.dashboard.poweruser.repository.PowerUserRepository;
+import com.team01.deokhugam.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DashboardBatchService {
   private final PowerUserRepository powerUserRepository;
+  private final UserRepository userRepository;
 
   @Transactional
   public void calculatePowerUserRanking(LocalDate baseDate) {
@@ -45,7 +47,7 @@ public class DashboardBatchService {
       for (int i = 0; i < rank.size(); i++) {
         UUID userId = rank.get(i).getKey();
         rankings.add(PowerUser.builder()
-            .user(/* TODO: userRepository.findById(userId) */)
+            .user(userRepository.findById(userId).orElseThrow())
             .period(period)
             .calculatedDate(OffsetDateTime.now(ZoneOffset.UTC))
             .rank(i + 1)

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
@@ -26,13 +26,13 @@ public class DashboardBatchService {
   public void calculatePowerUserRanking(LocalDate baseDate) {
 
     for (DashboardPeriod period : DashboardPeriod.values()) {
-      //1. 기간 시작/종료 시간
+      // 1. 기간 시작/종료 시간
       OffsetDateTime start = period.getStartDateTime(baseDate).atOffset(ZoneOffset.UTC);
       OffsetDateTime end = period.getEndDateTime(baseDate).atOffset(ZoneOffset.UTC);
-      // 2.유저별 데이터 조회
-      // TODO: 유저별 리뷰 인기점수 합 조회
-      // TODO: 유저별 좋아요 수 조회
-      // TODO: 유저별 댓글 수 조회
+      // 2. 유저별 데이터 조회
+      // TODO: 유저별 리뷰 인기점수 합 조회 (start, end 사용)
+      // TODO: 유저별 좋아요 수 조회 (start, end 사용)
+      // TODO: 유저별 댓글 수 조회 (start, end 사용)
       // 3. 점수 계산
       Map<UUID, Double> activityScoreMap = new HashMap<>();
       // activityScoreMap.put(userId, (reviewScoreSum * 0.5) + (likeCount * 0.2) + (commentCount * 0.3));
@@ -40,6 +40,9 @@ public class DashboardBatchService {
       List<Map.Entry<UUID, Double>> rank = activityScoreMap.entrySet().stream()
           .sorted(Map.Entry.<UUID, Double>comparingByValue().reversed())
           .toList();
+      if (rank.isEmpty()) {
+        continue;
+      }
       // 5. 기존 삭제
       powerUserRepository.deleteByPeriod(period);
       // 6. 저장

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
@@ -1,29 +1,31 @@
 package com.team01.deokhugam.batch.service;
 
 import com.team01.deokhugam.batch.common.DashboardPeriod;
-import com.team01.deokhugam.dashboard.poweruser.entity.PowerUser;
 import com.team01.deokhugam.dashboard.poweruser.repository.PowerUserRepository;
 import com.team01.deokhugam.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DashboardBatchService {
+
   private final PowerUserRepository powerUserRepository;
   private final UserRepository userRepository;
+  private final DashboardBatchTransactionService dashboardBatchTransactionService;
 
-  @Transactional
   public void calculatePowerUserRanking(LocalDate baseDate) {
+
+    OffsetDateTime calculatedAt = OffsetDateTime.now(ZoneOffset.UTC);
 
     for (DashboardPeriod period : DashboardPeriod.values()) {
       // 1. 기간 시작/종료 시간
@@ -43,24 +45,12 @@ public class DashboardBatchService {
       if (rank.isEmpty()) {
         continue;
       }
-      // 5. 기존 삭제
-      powerUserRepository.deleteByPeriod(period);
-      // 6. 저장
-      List<PowerUser> rankings = new ArrayList<>();
-      for (int i = 0; i < rank.size(); i++) {
-        UUID userId = rank.get(i).getKey();
-        rankings.add(PowerUser.builder()
-            .user(userRepository.findById(userId).orElseThrow())
-            .period(period)
-            .calculatedDate(OffsetDateTime.now(ZoneOffset.UTC))
-            .rank(i + 1)
-            .score(rank.get(i).getValue())
-            .reviewScoreSum(0.0) // TODO
-            .likeCount(0L) // TODO
-            .commentCount(0L) // TODO
-            .build());
+      // 5. 삭제 및 저장
+      try {
+        dashboardBatchTransactionService.deleteAndSave(period, rank, calculatedAt);
+      } catch (Exception e) {
+        log.error("랭킹 계산 실패: {}", period, e);
       }
-      powerUserRepository.saveAll(rankings);
     }
 
   }

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class DashboardBatchService {
 
-  private final PowerUserRepository powerUserRepository;
-  private final UserRepository userRepository;
   private final DashboardBatchTransactionService dashboardBatchTransactionService;
 
   public void calculatePowerUserRanking(LocalDate baseDate) {

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
@@ -1,5 +1,62 @@
 package com.team01.deokhugam.batch.service;
 
-public class DashboardBatchService {
+import com.team01.deokhugam.batch.common.DashboardPeriod;
+import com.team01.deokhugam.dashboard.poweruser.entity.PowerUser;
+import com.team01.deokhugam.dashboard.poweruser.repository.PowerUserRepository;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Service
+@RequiredArgsConstructor
+public class DashboardBatchService {
+  private final PowerUserRepository powerUserRepository;
+
+  @Transactional
+  public void calculatePowerUserRanking(LocalDate baseDate) {
+
+    for (DashboardPeriod period : DashboardPeriod.values()) {
+      //1. 기간 시작/종료 시간
+      OffsetDateTime start = period.getStartDateTime(baseDate).atOffset(ZoneOffset.UTC);
+      OffsetDateTime end = period.getEndDateTime(baseDate).atOffset(ZoneOffset.UTC);
+      // 2.유저별 데이터 조회
+      // TODO: 유저별 리뷰 인기점수 합 조회
+      // TODO: 유저별 좋아요 수 조회
+      // TODO: 유저별 댓글 수 조회
+      // 3. 점수 계산
+      Map<UUID, Double> activityScoreMap = new HashMap<>();
+      // activityScoreMap.put(userId, (reviewScoreSum * 0.5) + (likeCount * 0.2) + (commentCount * 0.3));
+      // 4. rank 부여
+      List<Map.Entry<UUID, Double>> rank = activityScoreMap.entrySet().stream()
+          .sorted(Map.Entry.<UUID, Double>comparingByValue().reversed())
+          .toList();
+      // 5. 기존 삭제
+      powerUserRepository.deleteByPeriod(period);
+      // 6. 저장
+      List<PowerUser> rankings = new ArrayList<>();
+      for (int i = 0; i < rank.size(); i++) {
+        UUID userId = rank.get(i).getKey();
+        rankings.add(PowerUser.builder()
+            .user(/* TODO: userRepository.findById(userId) */)
+            .period(period)
+            .calculatedDate(OffsetDateTime.now(ZoneOffset.UTC))
+            .rank(i + 1)
+            .score(rank.get(i).getValue())
+            .reviewScoreSum(0.0) // TODO
+            .likeCount(0L) // TODO
+            .commentCount(0L) // TODO
+            .build());
+      }
+      powerUserRepository.saveAll(rankings);
+    }
+
+  }
 }

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchTransactionService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchTransactionService.java
@@ -1,0 +1,61 @@
+package com.team01.deokhugam.batch.service;
+
+import com.team01.deokhugam.batch.common.DashboardPeriod;
+import com.team01.deokhugam.dashboard.poweruser.entity.PowerUser;
+import com.team01.deokhugam.dashboard.poweruser.repository.PowerUserRepository;
+import com.team01.deokhugam.global.exception.user.UserNotFoundException;
+import com.team01.deokhugam.user.entity.User;
+import com.team01.deokhugam.user.repository.UserRepository;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardBatchTransactionService {
+
+  private final PowerUserRepository powerUserRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void deleteAndSave(DashboardPeriod period, List<Map.Entry<UUID, Double>> rank,
+      OffsetDateTime calculatedAt) {
+
+    List<UUID> userIds = rank.stream()
+        .map(Map.Entry::getKey)
+        .toList();
+
+    Map<UUID, User> mapUser = userRepository.findAllById(userIds)
+        .stream().collect(Collectors.toMap(User::getId, u -> u));
+
+    //  기존 삭제
+    powerUserRepository.deleteByPeriod(period);
+    //  저장
+    List<PowerUser> rankings = new ArrayList<>();
+    for (int i = 0; i < rank.size(); i++) {
+      UUID userId = rank.get(i).getKey();
+      User user = mapUser.get(userId);
+      if (user == null) {
+        throw new UserNotFoundException(userId);
+      }
+      rankings.add(PowerUser.builder()
+          .user(user)
+          .period(period)
+          .calculatedDate(calculatedAt)
+          .rank(i + 1)
+          .score(rank.get(i).getValue())
+          .reviewScoreSum(0.0) // TODO
+          .likeCount(0L) // TODO
+          .commentCount(0L) // TODO
+          .build());
+    }
+    powerUserRepository.saveAll(rankings);
+  }
+
+}

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchTransactionService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchTransactionService.java
@@ -34,8 +34,17 @@ public class DashboardBatchTransactionService {
     Map<UUID, User> mapUser = userRepository.findAllById(userIds)
         .stream().collect(Collectors.toMap(User::getId, u -> u));
 
+    if (mapUser.size() != userIds.size()) {
+      UUID missing = userIds.stream()
+          .filter(id -> !mapUser.containsKey(id))
+          .findFirst()
+          .orElseThrow();
+      throw new UserNotFoundException(missing);
+    }
+
     //  기존 삭제
     powerUserRepository.deleteByPeriod(period);
+
     //  저장
     List<PowerUser> rankings = new ArrayList<>();
     for (int i = 0; i < rank.size(); i++) {

--- a/src/main/java/com/team01/deokhugam/dashboard/poweruser/repository/PowerUserRepository.java
+++ b/src/main/java/com/team01/deokhugam/dashboard/poweruser/repository/PowerUserRepository.java
@@ -8,12 +8,15 @@ import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
-  void deleteByPeriod(DashboardPeriod period);
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM PowerUser p WHERE p.period = :period")
+  void deleteByPeriod(@Param("period") DashboardPeriod period);
 
   @EntityGraph(attributePaths = "user")
   List<PowerUser> findByPeriodOrderByRankAsc(DashboardPeriod period, Pageable pageable);

--- a/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
@@ -156,17 +156,26 @@ public interface UserApi {
   /// GET - /api/users/power - 파워 유저 목록 조회
   @Operation(summary = "파워 유저 목록 조회", description = "기간별 파워 유저 목록을 조회합니다.")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "파워 유저 목록 조회 성공"),
+      @ApiResponse(
+          responseCode = "200", description = "파워 유저 목록 조회 성공",
+          content = @Content(schema = @Schema(implementation = CursorPageResponse.class))
+      ),
       @ApiResponse(responseCode = "400", description = "잘못된 요청 (랭킹 기간 오류, 정렬 방향 오류 등)"),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })
   ResponseEntity<CursorPageResponse<PowerUserDto>> findPowerUser(
+      @Parameter(description = "랭킹 기간", example = "DAILY")
       @RequestParam(defaultValue = "DAILY") DashboardPeriod period,
+      @Parameter(description = "정렬 방향", example = "ASC")
       @RequestParam(defaultValue = "ASC") SortDirection direction,
+      @Parameter(description = "이전 페이지의 마지막 rank(커서)")
       @RequestParam(required = false) String cursor,
+      @Parameter(description = "이전 페이지 마지막 항목의 생성 시각")
       @RequestParam(required = false) OffsetDateTime after,
+      @Parameter(description = "페이지 크기 (1~100)")
       @RequestParam(defaultValue = "50") @Min(1) @Max(100) int limit
   );
+
 
   /// DELETE - /api/users/{userId}/hard - 사용자 물리 삭제
   @Operation(summary = "사용자 물리 삭제", description = "사용자를 물리적으로 삭제합니다.")

--- a/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserApi.java
@@ -1,5 +1,9 @@
 package com.team01.deokhugam.user.controller;
 
+import com.team01.deokhugam.batch.common.DashboardPeriod;
+import com.team01.deokhugam.global.enums.SortDirection;
+import com.team01.deokhugam.global.pagination.CursorPageResponse;
+import com.team01.deokhugam.user.dto.PowerUserDto;
 import com.team01.deokhugam.user.dto.UserDto;
 import com.team01.deokhugam.user.dto.UserLoginRequest;
 import com.team01.deokhugam.user.dto.UserRegisterRequest;
@@ -14,9 +18,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "사용자 관리", description = "사용자 관련 API")
 public interface UserApi {
@@ -146,6 +154,19 @@ public interface UserApi {
   );
 
   /// GET - /api/users/power - 파워 유저 목록 조회
+  @Operation(summary = "파워 유저 목록 조회", description = "기간별 파워 유저 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "파워 유저 목록 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (랭킹 기간 오류, 정렬 방향 오류 등)"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ResponseEntity<CursorPageResponse<PowerUserDto>> findPowerUser(
+      @RequestParam(defaultValue = "DAILY") DashboardPeriod period,
+      @RequestParam(defaultValue = "ASC") SortDirection direction,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) OffsetDateTime after,
+      @RequestParam(defaultValue = "50") @Min(1) @Max(100) int limit
+  );
 
   /// DELETE - /api/users/{userId}/hard - 사용자 물리 삭제
   @Operation(summary = "사용자 물리 삭제", description = "사용자를 물리적으로 삭제합니다.")

--- a/src/main/java/com/team01/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserController.java
@@ -1,8 +1,11 @@
 package com.team01.deokhugam.user.controller;
 
+import com.team01.deokhugam.batch.common.DashboardPeriod;
+import com.team01.deokhugam.dashboard.poweruser.service.PowerUserService;
 import com.team01.deokhugam.global.constant.AuthHeader;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.user.UserAccessDeniedException;
+import com.team01.deokhugam.global.pagination.CursorPageResponse;
 import com.team01.deokhugam.user.dto.PowerUserDto;
 import com.team01.deokhugam.user.dto.UserDto;
 import com.team01.deokhugam.user.dto.UserLoginRequest;
@@ -32,9 +35,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserApi {
 
   private final UserService userService;
+  private final PowerUserService powerUserService;
 
-  public UserController(UserService userService) {
+  public UserController(UserService userService, PowerUserService powerUserService) {
     this.userService = userService;
+    this.powerUserService  = powerUserService;
   }
 
   /// POST - /api/users - 회원가입
@@ -96,7 +101,19 @@ public class UserController implements UserApi {
   }
 
   /// GET - /api/users/power - 파워 유저 목록 조회
-
+  @GetMapping("/power")
+  public ResponseEntity<CursorPageResponse<PowerUserDto>> findPowerUser(
+      @RequestParam(defaultValue = "DAILY") DashboardPeriod period,
+      @RequestParam(defaultValue = "ASC") SortDirection direction,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) OffsetDateTime after,
+      @RequestParam(defaultValue = "50") int limit
+  ){
+    log.info("파워 유저 조회 요청");
+    CursorPageResponse<PowerUserDto> result = powerUserService.getRanking(period,direction,cursor,after,limit);
+    log.info("파워 유저 조회 완료");
+    return ResponseEntity.ok(result);
+  }
 
   /// DELETE - /api/users/{userId}/hard - 사용자 물리 삭제
   @DeleteMapping("/{userId}/hard")

--- a/src/main/java/com/team01/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/team01/deokhugam/user/controller/UserController.java
@@ -13,6 +13,8 @@ import com.team01.deokhugam.user.dto.UserRegisterRequest;
 import com.team01.deokhugam.user.dto.UserUpdateRequest;
 import com.team01.deokhugam.user.service.UserService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +41,7 @@ public class UserController implements UserApi {
 
   public UserController(UserService userService, PowerUserService powerUserService) {
     this.userService = userService;
-    this.powerUserService  = powerUserService;
+    this.powerUserService = powerUserService;
   }
 
   /// POST - /api/users - 회원가입
@@ -107,11 +109,13 @@ public class UserController implements UserApi {
       @RequestParam(defaultValue = "ASC") SortDirection direction,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) OffsetDateTime after,
-      @RequestParam(defaultValue = "50") int limit
-  ){
-    log.info("파워 유저 조회 요청");
-    CursorPageResponse<PowerUserDto> result = powerUserService.getRanking(period,direction,cursor,after,limit);
-    log.info("파워 유저 조회 완료");
+      @RequestParam(defaultValue = "50") @Min(1) @Max(100) int limit
+  ) {
+    log.info("파워 유저 조회 요청 - period={}, direction={}, cursor={}, after={}, limit={}",
+        period, direction, cursor, after, limit);
+    CursorPageResponse<PowerUserDto> result =
+        powerUserService.getRanking(period, direction, cursor, after, limit);
+    log.info("파워 유저 조회 완료 - size={}, hasNext={}", result.size(), result.hasNext());
     return ResponseEntity.ok(result);
   }
 

--- a/src/test/java/com/team01/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/user/controller/UserControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team01.deokhugam.dashboard.poweruser.service.PowerUserService;
 import com.team01.deokhugam.global.constant.AuthHeader;
 import com.team01.deokhugam.user.dto.UserDto;
 import com.team01.deokhugam.user.dto.UserUpdateRequest;
@@ -40,6 +41,9 @@ class UserControllerTest {
 
   @MockitoBean
   private UserService userService;
+
+  @MockitoBean
+  private PowerUserService powerUserService;
 
   @Nested
   @DisplayName("PATCH /api/users/{userId} - 사용자 정보 수정")


### PR DESCRIPTION
## 📌 관련 이슈

- closes #184 

## 📝 작업 내용

- 파워유저 컨트롤러를 구현했습니다. 
- 유저 컨트롤러파일에 구현했습니다.

## 💡 변경 사항

- 변경사항 1

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 파워 유저 조회 API 추가: 기간·정렬로 필터링 가능한 커서 기반 페이지네이션 지원(옵션: cursor/after)
  * 조회 개수 제약(1–100, 기본 50) 및 기본값 적용
  * 배치 작업으로 파워 유저 랭킹 계산 및 갱신 기능 추가(순위 교체 방식)
  * API 문서화(응답/에러 스펙 명시)
* **테스트**
  * 관련 서비스 모킹 추가로 테스트 컨텍스트 보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->