### PR TITLE
fix: schema.sql과 PopularReview 엔티티 정합성 수정

### DIFF
--- a/src/main/java/com/team01/deokhugam/dashboard/popularreview/entity/PopularReview.java
+++ b/src/main/java/com/team01/deokhugam/dashboard/popularreview/entity/PopularReview.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,12 +25,12 @@ import lombok.NoArgsConstructor;
     name = "popular_reviews",
     uniqueConstraints = {
         @UniqueConstraint(
-            name = "uk_popular_reviews_review_period",
-            columnNames = {"review_id", "period"}
+            name = "uk_popular_reviews_period_rank",
+            columnNames = {"period_type", "calculated_date", "ranking"}
         ),
         @UniqueConstraint(
-            name = "uk_popular_reviews_period_rank",
-            columnNames = {"period", "ranking"}
+            name = "uk_popular_reviews_period_review",
+            columnNames = {"period_type", "calculated_date", "review_id"}
         )
     }
 )
@@ -42,8 +43,11 @@ public class PopularReview extends BaseEntity {
   private Review review;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "period", nullable = false, length = 20)
+  @Column(name = "period_type", nullable = false, length = 20)
   private DashboardPeriod period;
+
+  @Column(name = "calculated_date", nullable = false)
+  private LocalDate calculatedDate;
 
   @Column(name = "ranking", nullable = false)
   private int rank;
@@ -51,7 +55,7 @@ public class PopularReview extends BaseEntity {
   @Column(name = "score", nullable = false)
   private double score;
 
-  @Column(name = "like_count", nullable = false)
+  @Column(name = "liked_count", nullable = false)
   private int likeCount;
 
   @Column(name = "comment_count", nullable = false)
@@ -60,15 +64,17 @@ public class PopularReview extends BaseEntity {
   public PopularReview(
       Review review,
       DashboardPeriod period,
+      LocalDate calculatedDate,
       int rank,
       double score,
       int likeCount,
       int commentCount
   ) {
-    validate(review, period, rank, score, likeCount, commentCount);
+    validate(review, period, calculatedDate, rank, score, likeCount, commentCount);
 
     this.review = review;
     this.period = period;
+    this.calculatedDate = calculatedDate;
     this.rank = rank;
     this.score = score;
     this.likeCount = likeCount;
@@ -81,7 +87,7 @@ public class PopularReview extends BaseEntity {
       int likeCount,
       int commentCount
   ) {
-    validate(this.review, this.period, rank, score, likeCount, commentCount);
+    validate(this.review, this.period, this.calculatedDate, rank, score, likeCount, commentCount);
 
     this.rank = rank;
     this.score = score;
@@ -92,20 +98,20 @@ public class PopularReview extends BaseEntity {
   private void validate(
       Review review,
       DashboardPeriod period,
+      LocalDate calculatedDate,
       int rank,
       double score,
       int likeCount,
       int commentCount
   ) {
     if (review == null) {
-      throw new DeokhugamException(
-          ErrorCode.POPULAR_REVIEW_REVIEW_REQUIRED
-      );
+      throw new DeokhugamException(ErrorCode.POPULAR_REVIEW_REVIEW_REQUIRED);
     }
     if (period == null) {
-      throw new DeokhugamException(
-          ErrorCode.POPULAR_REVIEW_PERIOD_REQUIRED
-      );
+      throw new DeokhugamException(ErrorCode.POPULAR_REVIEW_PERIOD_REQUIRED);
+    }
+    if (calculatedDate == null) {
+      throw new DeokhugamException(ErrorCode.POPULAR_REVIEW_CALCULATED_DATE_REQUIRED);
     }
     if (rank < 1) {
       throw new DeokhugamException(
@@ -113,7 +119,7 @@ public class PopularReview extends BaseEntity {
           Map.of("rank", rank)
       );
     }
-    if (!Double.isFinite(score)) {
+    if (!Double.isFinite(score) || score < 0) {
       throw new DeokhugamException(
           ErrorCode.POPULAR_REVIEW_INVALID_SCORE,
           Map.of("score", String.valueOf(score))

--- a/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/team01/deokhugam/global/exception/ErrorCode.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
   // book
   INVALID_BOOK_SORT_FIELD(400, "INVALID_BOOK_SORT_FIELD", "알맞은 정렬 기준이 아닙니다."),
-  ISBN_UNIDENTIFIABLE(400,"ISBN_UNIDENTIFIABLE","ISBN을 식별 할 수 없습니다."),
-  INVALID_FILE(400, "INVALID_FILE","유효하지 않은 파일입니다"),
+  ISBN_UNIDENTIFIABLE(400, "ISBN_UNIDENTIFIABLE", "ISBN을 식별 할 수 없습니다."),
+  INVALID_FILE(400, "INVALID_FILE", "유효하지 않은 파일입니다"),
   EMPTY_FILE_UPLOADED(400, "EMPTY_FILE_UPLOADED", "비어있는 파일입니다."),
   BOOK_NOT_FOUND(404, "BOOK_NOT_FOUND", "해당하는 도서를 찾을 수 없습니다"),
   NAVER_BOOK_NOT_FOUND(404, "NAVER_BOOK_NOT_FOUND", "해당 ISBN의 도서를 찾을 수 없습니다"),
@@ -20,7 +20,7 @@ public enum ErrorCode {
   UNSUPPORTED_FILE_FORMAT(415, "UNSUPPORTED_FILE_FORMAT", "지원하지 않는 파일 형식입니다."),
   THUMBNAIL_UPLOAD_FAIL(500, "THUMBNAIL_UPLOAD_FAIL", "썸네일 업로드에 실패했습니다"),
   API_CREDENTIAL_FAIL(500, "API_CREDENTIAL_FAIL", "해당 API 자격 증명에 실패했습니다"),
-  API_SERVER_ERROR(502 ,"API_SERVER_ERROR", "API 서버 오류가 발생했습니다"),
+  API_SERVER_ERROR(502, "API_SERVER_ERROR", "API 서버 오류가 발생했습니다"),
 
   // comment
   COMMENT_NOT_FOUND(404, "COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다."),
@@ -51,6 +51,9 @@ public enum ErrorCode {
       "좋아요 수는 0 이상이어야 합니다."),
   POPULAR_REVIEW_INVALID_COMMENT_COUNT(400, "POPULAR_REVIEW_INVALID_COMMENT_COUNT",
       "댓글 수는 0 이상이어야 합니다."),
+  POPULAR_REVIEW_CALCULATED_DATE_REQUIRED(400, "POPULAR_REVIEW_CALCULATED_DATE_REQUIRED",
+      "인기 리뷰 집계일은 필수입니다."
+  ),
 
   // user
   EMAIL_ALREADY_EXISTS(409, "EMAIL_ALREADY_EXISTS", "이미 등록된 이메일입니다."),

--- a/src/main/java/com/team01/deokhugam/notification/entity/Notification.java
+++ b/src/main/java/com/team01/deokhugam/notification/entity/Notification.java
@@ -43,7 +43,7 @@ public class Notification extends BaseUpdatableEntity {
   private boolean isRead = false;
 
   @Column(name = "confirmed_at")
-  private OffsetDateTime confirmedAt; // 스키마 파일에 없는 필드 추가
+  private OffsetDateTime confirmedAt;
 
   public Notification(Review review, User user, String content) {
     this.review = Objects.requireNonNull(review, "리뷰ID는 null 일 수 없습니다");

--- a/src/main/java/com/team01/deokhugam/review/entity/ReviewLike.java
+++ b/src/main/java/com/team01/deokhugam/review/entity/ReviewLike.java
@@ -1,7 +1,7 @@
 package com.team01.deokhugam.review.entity;
 
 
-import com.team01.deokhugam.global.entity.BaseEntity;
+import com.team01.deokhugam.global.entity.BaseUpdatableEntity;
 import com.team01.deokhugam.user.entity.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
     }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReviewLike extends BaseEntity {
+public class ReviewLike extends BaseUpdatableEntity {
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "review_id", nullable = false)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -113,8 +113,7 @@ CREATE TABLE IF NOT EXISTS popular_books
     id              UUID PRIMARY KEY,
     book_id         UUID             NOT NULL,
     period_type     VARCHAR(20)      NOT NULL CHECK (period_type IN
-                                                     ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY',
-                                                      'ALL_TIME')),
+                                                     ('DAILY', 'WEEKLY', 'MONTHLY', 'ALL_TIME')),
     calculated_date DATE             NOT NULL, -- 랭킹 산정 기준일 (시간은 필요 없으므로 DATE)
     rank            INTEGER          NOT NULL CHECK (rank > 0),
     score           DOUBLE PRECISION NOT NULL CHECK (score >= 0),
@@ -133,20 +132,19 @@ CREATE INDEX IF NOT EXISTS idx_popular_books_book_id ON popular_books (book_id);
 CREATE TABLE IF NOT EXISTS popular_reviews
 (
     id              UUID PRIMARY KEY,
-    review_id       UUID           NOT NULL,
-    period_type     VARCHAR(20)    NOT NULL CHECK (period_type IN
-                                                   ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY',
-                                                    'ALL_TIME')),
-    calculated_date DATE           NOT NULL,
-    ranking         INTEGER        NOT NULL CHECK (ranking > 0),
-    score           NUMERIC(10, 2) NOT NULL CHECK (score >= 0),
-    liked_count     INTEGER        NOT NULL DEFAULT 0 CHECK (liked_count >= 0),
-    comment_count   INTEGER        NOT NULL DEFAULT 0 CHECK (comment_count >= 0),
+    review_id       UUID             NOT NULL,
+    period_type     VARCHAR(20)      NOT NULL CHECK (period_type IN
+                                                   ('DAILY', 'WEEKLY', 'MONTHLY', 'ALL_TIME')),
+    calculated_date DATE             NOT NULL,
+    ranking         INTEGER          NOT NULL CHECK (ranking > 0),
+    score           DOUBLE PRECISION NOT NULL CHECK (score >= 0),
+    liked_count     INTEGER          NOT NULL DEFAULT 0 CHECK (liked_count >= 0),
+    comment_count   INTEGER          NOT NULL DEFAULT 0 CHECK (comment_count >= 0),
 
-    created_at      TIMESTAMPTZ    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at      TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_popular_reviews_review FOREIGN KEY (review_id) REFERENCES reviews (id) ON DELETE CASCADE,
-    CONSTRAINT uk_popular_reviews_period_rank UNIQUE (period_type, calculated_date, rank),
+    CONSTRAINT uk_popular_reviews_period_rank UNIQUE (period_type, calculated_date, ranking),
     CONSTRAINT uk_popular_reviews_period_review UNIQUE (period_type, calculated_date, review_id)
 );
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -138,7 +138,7 @@ CREATE TABLE IF NOT EXISTS popular_reviews
                                                    ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY',
                                                     'ALL_TIME')),
     calculated_date DATE           NOT NULL,
-    rank            INTEGER        NOT NULL CHECK (rank > 0),
+    ranking         INTEGER        NOT NULL CHECK (ranking > 0),
     score           NUMERIC(10, 2) NOT NULL CHECK (score >= 0),
     liked_count     INTEGER        NOT NULL DEFAULT 0 CHECK (liked_count >= 0),
     comment_count   INTEGER        NOT NULL DEFAULT 0 CHECK (comment_count >= 0),


### PR DESCRIPTION
## 📌 관련 이슈

## 📝 작업 내용

- schema.sql과 PopularReview 엔티티 정합성 수정

## 💡 변경 사항

- 변경사항 1

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인기 리뷰 데이터 검증 로직 강화
  * 유효하지 않은 점수 값 거부 개선

* **기능 변경**
  * 인기 도서 및 리뷰 주기 옵션에서 '연도별' 제거 (일일, 주간, 월간, 전체만 지원)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->