### PR TITLE
fix: 리뷰 평점 수정 & 삭제시 도서 목록에 반영안되는 문제 해결

### DIFF
--- a/src/main/java/com/team01/deokhugam/book/entity/Book.java
+++ b/src/main/java/com/team01/deokhugam/book/entity/Book.java
@@ -83,9 +83,31 @@ public class Book extends BaseRemovableEntity {
     this.thumbnailUrl = newUrl;
   }
 
-  public void updateRating(double newRating){
+  public void plusRating(double newRating){
     double totalRating = this.rating * this.reviewCount;
     this.reviewCount += 1;
+    totalRating += newRating;
+    this.rating = totalRating / this.reviewCount;
+  }
+
+  public void minusRating(double oldRating){
+    double totalRating = this.rating * this.reviewCount;
+    this.reviewCount -= 1;
+    totalRating -= oldRating;
+
+
+    if (this.reviewCount <= 0) {
+      this.reviewCount = 0;
+      this.rating = 0.0;
+    } else {
+      // 부동소수점 연산 오차로 인한 미세한 음수(-0.000001 등)만 0.0으로 방어
+      this.rating = Math.max(0.0, totalRating / this.reviewCount);
+    }
+  }
+
+  public void modifyRating(double oldRating, double newRating){
+    double totalRating = this.rating * this.reviewCount;
+    totalRating -= oldRating;
     totalRating += newRating;
     this.rating = totalRating / this.reviewCount;
   }

--- a/src/main/java/com/team01/deokhugam/book/repository/BookRepository.java
+++ b/src/main/java/com/team01/deokhugam/book/repository/BookRepository.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, UUID>, BookRepositoryQueryDsl {
-  boolean existsByIsbn(String isbn);
+  boolean existsByIsbnAndIsDeletedFalse(String isbn);
 
   Optional<Book> findByIdAndIsDeletedFalse(UUID id);
 

--- a/src/main/java/com/team01/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/team01/deokhugam/book/service/BookService.java
@@ -180,12 +180,7 @@ public class BookService {
   @Transactional(readOnly = true)
   public BookDto findBook(UUID bookId){
     log.debug("도서 단건 조회: bookId={}", bookId);
-    Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
-        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
-            Map.of(
-                "bookId", bookId,
-                "rule", "DB에 해당 id의 책이 있어야합니다."
-            )));
+    Book book = findBookOrThrow(bookId);
 
     return bookMapper.toDto(book);
   }
@@ -193,12 +188,7 @@ public class BookService {
   @Transactional
   public BookDto updateBook(BookUpdateRequest request, UUID bookId, MultipartFile thumbnailImage) {
     log.debug("도서 정보 수정 시작: bookId={}", bookId);
-    Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
-        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
-            Map.of(
-                "bookId", bookId,
-                "rule", "DB에 해당 id의 책이 있어야합니다."
-            )));
+    Book book = findBookOrThrow(bookId);
 
     if(request.getTitle() != null){
       book.updateTitle(request.getTitle());
@@ -416,37 +406,31 @@ public class BookService {
 
   @Transactional
   public void plusBookReviewRating(UUID bookId, double rating){
-    Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
-        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
-            Map.of(
-                "bookId", bookId,
-                "rule", "DB에 해당 id의 책이 있어야합니다."
-            )));
+    Book book = findBookOrThrow(bookId);
 
     book.plusRating(rating);
   }
 
   @Transactional
   public void minusBookReviewRating(UUID bookId, double rating){
-    Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
-        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
-            Map.of(
-                "bookId", bookId,
-                "rule", "DB에 해당 id의 책이 있어야합니다."
-            )));
+    Book book = findBookOrThrow(bookId);
 
     book.minusRating(rating);
   }
 
   @Transactional
   public void modifyBookReviewRating(UUID bookId, double oldRating, double newRating){
-    Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
+    Book book = findBookOrThrow(bookId);
+
+    book.modifyRating(oldRating, newRating);
+  }
+
+  private Book findBookOrThrow(UUID bookId){
+    return bookRepository.findByIdAndIsDeletedFalse(bookId)
         .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
             Map.of(
                 "bookId", bookId,
                 "rule", "DB에 해당 id의 책이 있어야합니다."
             )));
-
-    book.modifyRating(oldRating, newRating);
   }
 }

--- a/src/main/java/com/team01/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/team01/deokhugam/book/service/BookService.java
@@ -79,7 +79,7 @@ public class BookService {
     String safeIsbn = StringUtils.hasText(request.getIsbn()) ? request.getIsbn().trim() : null;
     log.debug("도서 등록 처리 시작: title={}, isbn={}", request.getTitle(), request.getIsbn());
     // isbn 중복 예외 처리
-    if (safeIsbn != null && bookRepository.existsByIsbn(safeIsbn)) {
+    if (safeIsbn != null && bookRepository.existsByIsbnAndIsDeletedFalse(safeIsbn)) {
       throw new DeokhugamException(ErrorCode.DUPLICATED_ISBN,
           Map.of("ISBN", safeIsbn,
               "rule", "동일한 isbn이 존재할 수 없습니다."
@@ -415,7 +415,7 @@ public class BookService {
   }
 
   @Transactional
-  public void updateBookReviewRating(UUID bookId, double rating){
+  public void plusBookReviewRating(UUID bookId, double rating){
     Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
         .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
             Map.of(
@@ -423,6 +423,30 @@ public class BookService {
                 "rule", "DB에 해당 id의 책이 있어야합니다."
             )));
 
-    book.updateRating(rating);
+    book.plusRating(rating);
+  }
+
+  @Transactional
+  public void minusBookReviewRating(UUID bookId, double rating){
+    Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
+            Map.of(
+                "bookId", bookId,
+                "rule", "DB에 해당 id의 책이 있어야합니다."
+            )));
+
+    book.minusRating(rating);
+  }
+
+  @Transactional
+  public void modifyBookReviewRating(UUID bookId, double oldRating, double newRating){
+    Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND,
+            Map.of(
+                "bookId", bookId,
+                "rule", "DB에 해당 id의 책이 있어야합니다."
+            )));
+
+    book.modifyRating(oldRating, newRating);
   }
 }

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
@@ -73,7 +73,7 @@ public class ReviewServiceImpl implements ReviewService {
     );
     Review savedReview = reviewRepository.save(review);
 
-    bookService.updateBookReviewRating(book.getId(),review.getRating());
+    bookService.plusBookReviewRating(book.getId(),review.getRating());
 
     return reviewMapper.toDto(savedReview);
   }
@@ -157,13 +157,18 @@ public class ReviewServiceImpl implements ReviewService {
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
         .orElseThrow(() -> new ReviewNotFoundException(reviewId));
 
+    double oldRating = review.getRating();
+    double newRating = request.rating();
     // 사용자가 쓴 리뷰인지 검증(NPE)
     if (!review.getUser().getId().equals(requestUserId)) {
       throw new ReviewUpdateForbiddenException(reviewId, requestUserId);
     }
 
     // 리뷰 수정
-    review.update(request.content(), request.rating());
+    review.update(request.content(), newRating);
+
+    // 평균 평점 수정
+    bookService.modifyBookReviewRating(review.getBook().getId(), oldRating, newRating);
 
     return reviewMapper.toDto(review);
   }
@@ -179,6 +184,9 @@ public class ReviewServiceImpl implements ReviewService {
     if (!review.getUser().getId().equals(requestUserId)) {
       throw new ReviewUpdateForbiddenException(reviewId, requestUserId);
     }
+
+    // 평균 평점 수정
+    bookService.minusBookReviewRating(review.getBook().getId(), review.getRating());
 
     // 리뷰 논리 삭제
     review.softDelete();

--- a/src/test/java/com/team01/deokhugam/book/entity/BookRatingTest.java
+++ b/src/test/java/com/team01/deokhugam/book/entity/BookRatingTest.java
@@ -1,0 +1,53 @@
+package com.team01.deokhugam.book.entity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.offset;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class BookRatingTest {
+
+  private Book buildBook() {
+    return Book.builder()
+        .title("테스트 책")
+        .author("저자")
+        .description("설명")
+        .publisher("출판사")
+        .publishedDate(LocalDate.of(2024, 1, 1))
+        .isbn("1234567890123")
+        .build();
+  }
+
+  @Test
+  void plusRating_건수와_평균이_올바르게_업데이트된다() {
+    Book book = buildBook();
+    book.plusRating(4.0);  // 첫 번째 리뷰
+    book.plusRating(2.0);  // 두 번째 리뷰
+
+    assertThat(book.getReviewCount()).isEqualTo(2);
+    assertThat(book.getRating()).isEqualTo(3.0, offset(0.001)); // (4+2)/2 = 3.0
+  }
+
+  @Test
+  void minusRating_리뷰가_1개일때_삭제하면_0점_0건으로_초기화된다() {
+    Book book = buildBook();
+    book.plusRating(5.0);
+    book.minusRating(5.0);
+
+    assertThat(book.getReviewCount()).isEqualTo(0);
+    assertThat(book.getRating()).isEqualTo(0.0, offset(0.001));
+  }
+
+  @Test
+  void modifyRating_건수는_유지되고_평균만_바뀐다() {
+    Book book = buildBook();
+    book.plusRating(4.0);
+    book.plusRating(4.0);
+    // 현재 평균 4.0, 건수 2
+    book.modifyRating(4.0, 2.0); // 한 리뷰를 4점→2점으로 수정
+
+    assertThat(book.getReviewCount()).isEqualTo(2); // 건수 유지
+    assertThat(book.getRating()).isEqualTo(3.0, offset(0.001)); // (4+2)/2 = 3.0
+  }
+}

--- a/src/test/java/com/team01/deokhugam/book/service/BookServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/book/service/BookServiceTest.java
@@ -123,7 +123,7 @@ class BookServiceTest {
   void createBook_without_thumbnail_Success() {
     // given
     Book savedBook = book;
-    given(bookRepository.existsByIsbn(anyString())).willReturn(false); // ISBN 중복 아님
+    given(bookRepository.existsByIsbnAndIsDeletedFalse(anyString())).willReturn(false); // ISBN 중복 아님
     given(bookRepository.saveAndFlush(any(Book.class))).willReturn(savedBook); // 저장하면 book 반환
     given(bookMapper.toDto(savedBook)).willReturn(bookDto); // 매퍼 호출 시 bookDto 반환
 
@@ -140,7 +140,7 @@ class BookServiceTest {
     assertThat(result.getIsbn()).isEqualTo("1234567890");
 
     // 메서드들이 한번씩 호출되었는지 검사
-    verify(bookRepository).existsByIsbn("1234567890");
+    verify(bookRepository).existsByIsbnAndIsDeletedFalse("1234567890");
     verify(bookRepository).saveAndFlush(any(Book.class));
     verify(bookMapper).toDto(savedBook);
   }
@@ -152,7 +152,7 @@ class BookServiceTest {
     MultipartFile mockFile = new MockMultipartFile("thumbnail", "test.jpg", "image/jpeg", "test data".getBytes());
     String expectedS3Url = "https://s3.aws.com/test.jpg";
 
-    given(bookRepository.existsByIsbn(anyString())).willReturn(false);
+    given(bookRepository.existsByIsbnAndIsDeletedFalse(anyString())).willReturn(false);
     given(s3ThumbnailStorage.upload(mockFile)).willReturn(expectedS3Url);
     given(bookRepository.saveAndFlush(any(Book.class))).willReturn(book);
     given(bookMapper.toDto(book)).willReturn(bookDto);
@@ -180,7 +180,7 @@ class BookServiceTest {
     MultipartFile mockFile = new MockMultipartFile("thumbnail", "test.jpg", "image/jpeg", "test data".getBytes());
     String expectedS3Url = "https://s3.aws.com/test.jpg";
 
-    given(bookRepository.existsByIsbn(anyString())).willReturn(false);
+    given(bookRepository.existsByIsbnAndIsDeletedFalse(anyString())).willReturn(false);
     given(s3ThumbnailStorage.upload(mockFile)).willReturn(expectedS3Url);
 
     // S3 업로드는 성공했지만, DB 저장 시점에 강제로 예외 터뜨리기
@@ -219,7 +219,7 @@ class BookServiceTest {
   @DisplayName("도서 등록 실패 - 이미 존재하는 ISBN일 때")
   void createBook_Fail_DuplicateIsbn() {
     // given
-    given(bookRepository.existsByIsbn(anyString())).willReturn(true);
+    given(bookRepository.existsByIsbnAndIsDeletedFalse(anyString())).willReturn(true);
 
     // when & then
     assertThatThrownBy(() -> bookService.createBook(request, null))
@@ -234,7 +234,7 @@ class BookServiceTest {
   @DisplayName("도서 등록 실패 - 동시성 문제(TOCTOU)로 DB 제약조건 위반 시 커스텀 예외 반환")
   void createBook_Fail_DataIntegrityViolation() {
     // given
-    given(bookRepository.existsByIsbn(anyString())).willReturn(false);
+    given(bookRepository.existsByIsbnAndIsDeletedFalse(anyString())).willReturn(false);
     // saveAndFlush 시점에 DB에서 강제로 중복 예외 발생
     given(bookRepository.saveAndFlush(any(Book.class)))
         .willThrow(new org.springframework.dao.DataIntegrityViolationException("Unique constraint violation"));

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -75,6 +75,7 @@ class ReviewServiceImplTest {
   private UUID userId;
   private UUID reviewId;
   private UUID requestUserId;
+  private UUID requestBookId;
   private UUID authorId;
 
   @BeforeEach
@@ -83,6 +84,7 @@ class ReviewServiceImplTest {
     userId = UUID.randomUUID();
     reviewId = UUID.randomUUID();
     requestUserId = UUID.randomUUID();
+    requestBookId = UUID.randomUUID();
     authorId = UUID.randomUUID();
   }
 
@@ -282,11 +284,12 @@ class ReviewServiceImplTest {
   @DisplayName("리뷰 수정 - 성공")
   void updateReview_success() {
     User user = mock(User.class);
+    Book book = mock(Book.class);
     Review review = mock(Review.class);
     ReviewUpdateRequest request = new ReviewUpdateRequest("수정된 리뷰", 4.5);
     ReviewDto reviewDto = new ReviewDto(
         reviewId,
-        UUID.randomUUID(),
+        requestBookId,
         "테스트 책",
         "thumb.jpg",
         requestUserId,
@@ -303,6 +306,8 @@ class ReviewServiceImplTest {
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
     given(review.getUser()).willReturn(user);
     given(user.getId()).willReturn(requestUserId);
+    given(review.getBook()).willReturn(book);
+    given(book.getId()).willReturn(requestBookId);
     given(reviewMapper.toDto(review)).willReturn(reviewDto);
 
     ReviewDto result = reviewServiceImpl.updateReview(reviewId, requestUserId, request);
@@ -335,10 +340,13 @@ class ReviewServiceImplTest {
   @DisplayName("리뷰 논리 삭제 - 성공")
   void deleteReview_success() {
     User author = mock(User.class);
+    Book book = mock(Book.class);
     Review review = mock(Review.class);
 
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
     given(review.getUser()).willReturn(author);
+    given(review.getBook()).willReturn(book);
+    given(book.getId()).willReturn(requestBookId);
     given(author.getId()).willReturn(requestUserId);
 
     reviewServiceImpl.deleteReview(reviewId, requestUserId);


### PR DESCRIPTION
## 📌 관련 이슈

- closes #222 

## 📝 작업 내용

- 평점 수정 메서드 분리(plus, minus, modify) 및 추가 구현
- reviewService에 메서드 주입
- isbn 중복 방지 해놓았는데 논리 삭제시 isbn이 남아있어서 도서 추가 등록이 안되서 isbn 등록시 isDeleted가 false인것중에 검사 -> 추후 유니크 제약 삭제해야함

## 💡 변경 사항

- updateRating 메서드 명 수정 및 분리 -> plus, minus, modify

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 리뷰 생성, 수정, 삭제 시 책의 평점 동기화를 개선하여 정확한 평점 계산을 보장합니다.
  * ISBN 중복 확인 검증이 개선되어 삭제된 책을 제외하고 올바르게 작동하도록 수정했습니다. 데이터 무결성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->