### PR TITLE
fix: books테이블 isbn컬럼 유니크 속성 제거

### DIFF
--- a/src/main/java/com/team01/deokhugam/book/entity/Book.java
+++ b/src/main/java/com/team01/deokhugam/book/entity/Book.java
@@ -31,7 +31,7 @@ public class Book extends BaseRemovableEntity {
   @Column(name = "published_date", nullable = false)
   private LocalDate publishedDate;
 
-  @Column(name = "isbn", unique = true, updatable = false, length = 20)
+  @Column(name = "isbn", updatable = false, length = 20)
   private String isbn;
 
   @Column(name = "thumbnail_url", length = 255)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS books
     description    TEXT             NOT NULL,
     publisher      VARCHAR(100)     NOT NULL,
     published_date DATE             NOT NULL,
-    isbn           VARCHAR(20) UNIQUE,
+    isbn           VARCHAR(20)      NOT NULL,
     thumbnail_url  VARCHAR(255),
     review_count   INTEGER          NOT NULL DEFAULT 0 CHECK (review_count >= 0),
     rating         DOUBLE PRECISION NOT NULL DEFAULT 0.0 CHECK (rating >= 0.0 AND rating <= 5.0),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS books
     description    TEXT             NOT NULL,
     publisher      VARCHAR(100)     NOT NULL,
     published_date DATE             NOT NULL,
-    isbn           VARCHAR(20)      NOT NULL,
+    isbn           VARCHAR(20),
     thumbnail_url  VARCHAR(255),
     review_count   INTEGER          NOT NULL DEFAULT 0 CHECK (review_count >= 0),
     rating         DOUBLE PRECISION NOT NULL DEFAULT 0.0 CHECK (rating >= 0.0 AND rating <= 5.0),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -31,6 +31,8 @@ CREATE TABLE IF NOT EXISTS books
     updated_at     TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS uk_books_active_isbn ON books (isbn) WHERE isbn IS NOT NULL AND is_deleted = FALSE;
+
 CREATE TABLE IF NOT EXISTS reviews
 (
     id            UUID PRIMARY KEY,


### PR DESCRIPTION
## 📌 관련 이슈

- closes #225 

## 📝 작업 내용

- 논리삭제된 도서와 같은 isbn의 도서는 다시 등록될 수 있어야해서 유니크 속성 제거

## 💡 변경 사항

- 논리삭제된 도서와 같은 isbn의 도서는 다시 등록될 수 있어야해서 유니크 속성 제거

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * ISBN 필드는 이제 필수 입력입니다.
  * ISBN 중복 입력이 이제 허용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->