### PR TITLE
fix: ocr Api 응답시간 초과 문제 해결

### DIFF
--- a/src/main/java/com/team01/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/team01/deokhugam/book/service/BookService.java
@@ -330,9 +330,8 @@ public class BookService {
       MultiValueMap<String, Object> formData = new LinkedMultiValueMap<>();
       formData.add("apikey", ocrApiKey);
       formData.add("file", image.getResource());
-      formData.add("language", "auto");
       formData.add("isOverlayRequired", "false");
-      formData.add("OCREngine", "2"); // 숫자 및 특수문자 인식에 더 강한 엔진 사용
+      // 숫자 및 특수문자 인식에 더 강한 엔진 사용
 
       OcrSpaceResponse response = ocrRestClient.post()
           .uri("/parse/image")

--- a/src/main/java/com/team01/deokhugam/global/config/ExternalApiConfig.java
+++ b/src/main/java/com/team01/deokhugam/global/config/ExternalApiConfig.java
@@ -41,8 +41,8 @@ public class ExternalApiConfig {
 
     // 타임 아웃 설정 - 대기 시간 지나면 바로 연결 끊어버림
     SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-    factory.setConnectTimeout((int) Duration.ofSeconds(10).toMillis()); // 3초 (연결대기 시간)
-    factory.setReadTimeout((int) Duration.ofSeconds(30).toMillis()); // 5초 (데이터 읽기 대기 시간)
+    factory.setConnectTimeout((int) Duration.ofSeconds(10).toMillis()); // 10초 (연결대기 시간)
+    factory.setReadTimeout((int) Duration.ofSeconds(15).toMillis()); // 15초 (데이터 읽기 대기 시간)
 
     return builder
         .requestFactory(factory) // 타임아웃 설정


### PR DESCRIPTION
## 📌 관련 이슈

- closes #247 

## 📝 작업 내용

- ocrRestClient 응답 지연시간 15초로 증가 (연결은 10초)
- ocrRestClient 요청 form-data 파라미터로 engine 파라미터 -> 1(기본) 수정, language파라미터 제거

## 💡 변경 사항

- ocrRestClient 응답 지연시간 15초로 증가 (연결은 10초)
- ocrRestClient 요청 form-data 파라미터로 engine 파라미터 -> 1(기본) 수정, language파라미터 제거

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)