### PR TITLE
feat: 파워 유저 활동 점수 집계 구현 (#252)

### DIFF
--- a/src/main/java/com/team01/deokhugam/batch/dto/UserActivityCountRow.java
+++ b/src/main/java/com/team01/deokhugam/batch/dto/UserActivityCountRow.java
@@ -1,0 +1,10 @@
+package com.team01.deokhugam.batch.dto;
+
+import java.util.UUID;
+
+public record UserActivityCountRow(
+    UUID userId,
+    long count
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/batch/dto/UserReviewScoreSumRow.java
+++ b/src/main/java/com/team01/deokhugam/batch/dto/UserReviewScoreSumRow.java
@@ -1,0 +1,10 @@
+package com.team01.deokhugam.batch.dto;
+
+import java.util.UUID;
+
+public record UserReviewScoreSumRow(
+    UUID userId,
+    double scoreSum
+) {
+
+}

--- a/src/main/java/com/team01/deokhugam/batch/repository/PowerUserBatchQueryRepository.java
+++ b/src/main/java/com/team01/deokhugam/batch/repository/PowerUserBatchQueryRepository.java
@@ -1,0 +1,10 @@
+package com.team01.deokhugam.batch.repository;
+
+import com.team01.deokhugam.review.entity.Review;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PowerUserBatchQueryRepository
+    extends JpaRepository<Review, UUID>, PowerUserBatchQueryRepositoryCustom {
+
+}

--- a/src/main/java/com/team01/deokhugam/batch/repository/PowerUserBatchQueryRepositoryCustom.java
+++ b/src/main/java/com/team01/deokhugam/batch/repository/PowerUserBatchQueryRepositoryCustom.java
@@ -1,0 +1,21 @@
+package com.team01.deokhugam.batch.repository;
+
+import com.team01.deokhugam.batch.common.DashboardPeriod;
+import com.team01.deokhugam.batch.dto.UserActivityCountRow;
+import com.team01.deokhugam.batch.dto.UserReviewScoreSumRow;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface PowerUserBatchQueryRepositoryCustom {
+
+  List<UserReviewScoreSumRow> findReviewScoreSumsByUser(
+      DashboardPeriod period,
+      LocalDate calculatedDate
+  );
+
+  List<UserActivityCountRow> findLikeCountsByUserBetween(
+      OffsetDateTime start,
+      OffsetDateTime end
+  );
+}

--- a/src/main/java/com/team01/deokhugam/batch/repository/PowerUserBatchQueryRepositoryImpl.java
+++ b/src/main/java/com/team01/deokhugam/batch/repository/PowerUserBatchQueryRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.team01.deokhugam.batch.repository;
+
+import static com.team01.deokhugam.dashboard.popularreview.entity.QPopularReview.popularReview;
+import static com.team01.deokhugam.review.entity.QReview.review;
+import static com.team01.deokhugam.review.entity.QReviewLike.reviewLike;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team01.deokhugam.batch.common.DashboardPeriod;
+import com.team01.deokhugam.batch.dto.UserActivityCountRow;
+import com.team01.deokhugam.batch.dto.UserReviewScoreSumRow;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PowerUserBatchQueryRepositoryImpl implements PowerUserBatchQueryRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<UserReviewScoreSumRow> findReviewScoreSumsByUser(
+      DashboardPeriod period,
+      LocalDate calculatedDate
+  ) {
+    return queryFactory
+        .select(Projections.constructor(
+            UserReviewScoreSumRow.class,
+            popularReview.review.user.id,
+            popularReview.score.sum().coalesce(0.0)
+        ))
+        .from(popularReview)
+        .where(
+            popularReview.period.eq(period),
+            popularReview.calculatedDate.eq(calculatedDate),
+            popularReview.review.isDeleted.isFalse(),
+            popularReview.review.user.isDeleted.isFalse()
+        )
+        .groupBy(popularReview.review.user.id)
+        .fetch();
+  }
+
+  @Override
+  public List<UserActivityCountRow> findLikeCountsByUserBetween(
+      OffsetDateTime start,
+      OffsetDateTime end
+  ) {
+    return queryFactory
+        .select(Projections.constructor(
+            UserActivityCountRow.class,
+            reviewLike.review.user.id,
+            reviewLike.count()
+        ))
+        .from(reviewLike)
+        .join(reviewLike.review, review)
+        .where(
+            reviewLike.createdAt.goe(start),
+            reviewLike.createdAt.lt(end),
+            review.isDeleted.isFalse(),
+            review.user.isDeleted.isFalse()
+        )
+        .groupBy(reviewLike.review.user.id)
+        .fetch();
+  }
+}

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
@@ -52,19 +52,22 @@ public class DashboardBatchService {
       Map<UUID, Double> reviewScoreSumMap = reviewScoreSums.stream()
           .collect(Collectors.toMap(
               UserReviewScoreSumRow::userId,
-              UserReviewScoreSumRow::scoreSum
+              UserReviewScoreSumRow::scoreSum,
+              Double::sum
           ));
 
       Map<UUID, Long> likeCountMap = likeCounts.stream()
           .collect(Collectors.toMap(
               UserActivityCountRow::userId,
-              UserActivityCountRow::count
+              UserActivityCountRow::count,
+              Long::sum
           ));
 
       Map<UUID, Long> commentCountMap = commentCounts.stream()
           .collect(Collectors.toMap(
               UserCommentCountRow::userId,
-              UserCommentCountRow::commentCount
+              UserCommentCountRow::commentCount,
+              Long::sum
           ));
 
       Set<UUID> userIds = new HashSet<>();

--- a/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
+++ b/src/main/java/com/team01/deokhugam/batch/service/DashboardBatchService.java
@@ -2,16 +2,23 @@ package com.team01.deokhugam.batch.service;
 
 import com.team01.deokhugam.batch.common.DashboardPeriod;
 import com.team01.deokhugam.batch.dto.PopularBookScoreRow;
+import com.team01.deokhugam.batch.dto.UserActivityCountRow;
+import com.team01.deokhugam.batch.dto.UserReviewScoreSumRow;
 import com.team01.deokhugam.batch.repository.PopularBookBatchQueryRepository;
+import com.team01.deokhugam.batch.repository.PowerUserBatchQueryRepository;
+import com.team01.deokhugam.comment.dto.UserCommentCountRow;
 import com.team01.deokhugam.comment.repository.CommentRepository;
 import com.team01.deokhugam.dashboard.popularreview.service.PopularReviewService;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +32,8 @@ public class DashboardBatchService {
   private final PopularBookBatchQueryRepository popularBookBatchQueryRepository;
   private final CommentRepository commentRepository;
   private final PopularReviewService popularReviewService;
+  private final PowerUserBatchQueryRepository powerUserBatchQueryRepository;
+
 
   public void calculatePowerUserRanking(LocalDate baseDate) {
 
@@ -35,16 +44,49 @@ public class DashboardBatchService {
       OffsetDateTime start = period.getStartDateTime(baseDate).atOffset(ZoneOffset.UTC);
       OffsetDateTime end = period.getEndDateTime(baseDate).atOffset(ZoneOffset.UTC);
       // 2. 유저별 데이터 조회
-      // TODO: 유저별 리뷰 인기점수 합 조회 (start, end 사용)
-
-      // TODO: 유저별 좋아요 수 조회 (start, end 사용)
-
-      // TODO: 유저별 댓글 수 조회 (start, end 사용)
+      var reviewScoreSums = powerUserBatchQueryRepository.findReviewScoreSumsByUser(period,
+          baseDate);
+      var likeCounts = powerUserBatchQueryRepository.findLikeCountsByUserBetween(start, end);
       var commentCounts = commentRepository.findCommentCountsByUserBetween(start, end);
       // 3. 점수 계산
+      Map<UUID, Double> reviewScoreSumMap = reviewScoreSums.stream()
+          .collect(Collectors.toMap(
+              UserReviewScoreSumRow::userId,
+              UserReviewScoreSumRow::scoreSum
+          ));
+
+      Map<UUID, Long> likeCountMap = likeCounts.stream()
+          .collect(Collectors.toMap(
+              UserActivityCountRow::userId,
+              UserActivityCountRow::count
+          ));
+
+      Map<UUID, Long> commentCountMap = commentCounts.stream()
+          .collect(Collectors.toMap(
+              UserCommentCountRow::userId,
+              UserCommentCountRow::commentCount
+          ));
+
+      Set<UUID> userIds = new HashSet<>();
+      userIds.addAll(reviewScoreSumMap.keySet());
+      userIds.addAll(likeCountMap.keySet());
+      userIds.addAll(commentCountMap.keySet());
+
       Map<UUID, Double> activityScoreMap = new HashMap<>();
-      // activityScoreMap.put(userId, (reviewScoreSum * 0.5) + (likeCount * 0.2) + (commentCounts *
-      // 0.3));
+
+      for (UUID userId : userIds) {
+        double reviewScoreSum = reviewScoreSumMap.getOrDefault(userId, 0.0);
+        long likeCount = likeCountMap.getOrDefault(userId, 0L);
+        long commentCount = commentCountMap.getOrDefault(userId, 0L);
+
+        double activityScore = reviewScoreSum * 0.5
+            + likeCount * 0.2
+            + commentCount * 0.3;
+
+        if (activityScore > 0) {
+          activityScoreMap.put(userId, activityScore);
+        }
+      }
       // 4. rank 부여
       List<Map.Entry<UUID, Double>> rank =
           activityScoreMap.entrySet().stream()


### PR DESCRIPTION
## 📌 관련 이슈

- closes #252 

## 📝 작업 내용

- 내용

## 💡 변경 사항

- PowerUserBatchQueryRepository 추가
- 유저별 리뷰 인기점수 합 조회 로직 추가
- 유저별 좋아요 수 조회 로직 추가
- 기존 댓글 수 조회 결과와 함께 활동 점수 계산
- 파워 유저 활동 점수 계산식 적용 reviewScoreSum * 0.5 + likeCount * 0.2 + commentCount * 0.3
- 활동 점수 기준 랭킹 정렬

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 파워 유저 랭킹 계산 기능을 지원하기 위한 배치 처리 인프라 강화
  * 사용자 활동 데이터(리뷰 점수 및 좋아요 수) 집계 기능 추가로 랭킹 알고리즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->