### PR TITLE
refactor: 알림 서비스 삭제 메서드 수정

### DIFF
--- a/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
@@ -14,7 +14,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
   List<Notification> findAllByUserIdAndIsReadFalse(UUID userId);
 
-  void deleteAllByIsReadTrueAndUpdatedAtBefore(OffsetDateTime cutoff);
+  void deleteAllByIsReadTrueAndConfirmedAtBefore(OffsetDateTime cutoff);
 
   long countByUserId(UUID userId);
 }

--- a/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/notification/service/NotificationServiceImpl.java
@@ -93,7 +93,7 @@ public class NotificationServiceImpl implements NotificationService {
     OffsetDateTime oneWeekAgo = OffsetDateTime.now(ZoneOffset.UTC).minusWeeks(1);
     log.info("[DELETE_NOTIFICATION] 1주일 경과 알림 삭제 시작 기준시간={}", oneWeekAgo);
 
-    notificationRepository.deleteAllByIsReadTrueAndUpdatedAtBefore(oneWeekAgo);
+    notificationRepository.deleteAllByIsReadTrueAndConfirmedAtBefore(oneWeekAgo);
 
     log.info("[DELETE_NOTIFICATION] 1주일 경과 알림 삭제 완료");
   }

--- a/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -232,9 +233,16 @@ public class NotificationServiceTest {
       //given
       //when
       notificationService.cleanupReadNotifications();
+      ArgumentCaptor<OffsetDateTime> cutoffCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
       //then
       then(notificationRepository).should()
-          .deleteAllByIsReadTrueAndConfirmedAtBefore(any(OffsetDateTime.class));
+          .deleteAllByIsReadTrueAndConfirmedAtBefore(cutoffCaptor.capture());
+      assertThat(cutoffCaptor.getValue())
+          .isBetween(
+              OffsetDateTime.now(ZoneOffset.UTC).minusWeeks(1).minusMinutes(1),
+              OffsetDateTime.now(ZoneOffset.UTC).minusWeeks(1).plusMinutes(1)
+
+          );
     }
   }
 
@@ -376,7 +384,8 @@ public class NotificationServiceTest {
       OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
       mockCursorPageRequest = new CursorPageRequest(null, fixedTime, 50);
       //when,then
-      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest, SortDirection.DESC))
+      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest,
+          SortDirection.DESC))
           .isInstanceOf(NotificationException.class);
 
     }
@@ -388,7 +397,8 @@ public class NotificationServiceTest {
       OffsetDateTime fixedTime = OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
       mockCursorPageRequest = new CursorPageRequest("invalid-uuid", fixedTime, 50);
       //when,then
-      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest, SortDirection.DESC))
+      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest,
+          SortDirection.DESC))
           .isInstanceOf(NotificationException.class);
     }
 
@@ -398,7 +408,8 @@ public class NotificationServiceTest {
       //given
       mockCursorPageRequest = new CursorPageRequest(UUID.randomUUID().toString(), null, 50);
       //when,then
-      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest, SortDirection.DESC))
+      assertThatThrownBy(() -> notificationService.findAll(mockUser.getId(), mockCursorPageRequest,
+          SortDirection.DESC))
           .isInstanceOf(NotificationException.class);
     }
   }

--- a/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/notification/NotificationServiceTest.java
@@ -234,7 +234,7 @@ public class NotificationServiceTest {
       notificationService.cleanupReadNotifications();
       //then
       then(notificationRepository).should()
-          .deleteAllByIsReadTrueAndUpdatedAtBefore(any(OffsetDateTime.class));
+          .deleteAllByIsReadTrueAndConfirmedAtBefore(any(OffsetDateTime.class));
     }
   }
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #

## 📝 작업 내용

- 알림 서비스의 삭제 메서드의 레포지토리 호출메서드를 수정했습니다

## 💡 변경 사항

- 변경사항 1

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **버그 수정**
  * 읽은 알림의 자동 삭제 로직을 개선하여, 마지막 수정 시간 대신 확인 시간 기준으로 정리하도록 변경했습니다. 이를 통해 알림 관리가 더욱 정확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->