### PR TITLE
feat: MDC에 요청별 id/ip 주소 추가

### DIFF
--- a/src/main/java/com/team01/deokhugam/batch/job/DashboardBatchJob.java
+++ b/src/main/java/com/team01/deokhugam/batch/job/DashboardBatchJob.java
@@ -18,7 +18,6 @@ public class DashboardBatchJob {
   private final NotificationService notificationService;
 
   @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
-  // @Scheduled(cron = "*/10 * * * * *", zone = "UTC")
   public void run() {
     log.info("[DASHBOARD_BATCH] 시작");
 

--- a/src/main/java/com/team01/deokhugam/batch/job/DashboardBatchJob.java
+++ b/src/main/java/com/team01/deokhugam/batch/job/DashboardBatchJob.java
@@ -18,6 +18,7 @@ public class DashboardBatchJob {
   private final NotificationService notificationService;
 
   @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
+  // @Scheduled(cron = "*/10 * * * * *", zone = "UTC")
   public void run() {
     log.info("[DASHBOARD_BATCH] 시작");
 

--- a/src/main/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilter.java
+++ b/src/main/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilter.java
@@ -1,16 +1,16 @@
 package com.team01.deokhugam.global.filter;
 
-import static org.springframework.util.StringUtils.hasText;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
-import org.jboss.logging.MDC;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Component
 public class RequestMdcLoggingFilter extends OncePerRequestFilter {
   // MDC 내부 로그용 key
   public static final String MDC_REQUEST_ID = "requestId";

--- a/src/main/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilter.java
+++ b/src/main/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilter.java
@@ -41,7 +41,8 @@ public class RequestMdcLoggingFilter extends OncePerRequestFilter {
       filterChain.doFilter(request, response);
     } finally {
       // 스레드 재사용 시 이전 요청 값 비우기
-      MDC.clear();
+      MDC.remove(MDC_REQUEST_ID);
+      MDC.remove(MDC_CLIENT_IP);
     }
   }
 

--- a/src/main/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilter.java
+++ b/src/main/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilter.java
@@ -1,0 +1,69 @@
+package com.team01.deokhugam.global.filter;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.jboss.logging.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class RequestMdcLoggingFilter extends OncePerRequestFilter {
+  // MDC 내부 로그용 key
+  public static final String MDC_REQUEST_ID = "requestId";
+  public static final String MDC_CLIENT_IP = "clientIp";
+
+  // HTTP 응답 해더
+  public static final String HEADER_REQUEST_ID = "X-Request-Id";
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    // 요청별 추적 ID 생성 - 계층별 로그 여러개더라도 같은 id 공유
+    String requestId = UUID.randomUUID().toString();
+
+    // 프록시 고려, 클라이언트 IP 추출
+    String clientIp = resolveClientIp(request);
+
+    try {
+      // 현재 요청 처리중인 스레드의 MDC에 저장
+      // 이후 같은 요청 흐름에서 찍히는 로그는 requestId, clientIp를 같이 출력
+      MDC.put(MDC_REQUEST_ID, requestId);
+      MDC.put(MDC_CLIENT_IP, clientIp);
+
+      // 클라이언트가 추적할 수 있도록 응답헤더에도 requestId
+      response.setHeader(HEADER_REQUEST_ID, requestId);
+
+      filterChain.doFilter(request, response);
+    } finally {
+      // 스레드 재사용 시 이전 요청 값 비우기
+      MDC.clear();
+    }
+  }
+
+  private String resolveClientIp(HttpServletRequest request) {
+    String xForwardedFor = request.getHeader("X-Forwarded-For");
+    if (hasText(xForwardedFor)) {
+      // 프록시를 여러 번 거쳤다면 첫 번째 IP를 실제 클라이언트 IP로 본다.
+      // X-Forwarded-For : 203.0.113.10, 10.0.0.3, 10.0.0.4
+      return xForwardedFor.split(",")[0].trim();
+    }
+
+    String xRealIp = request.getHeader("X-Real-IP");
+
+    if (hasText(xRealIp)) {
+      return xRealIp.trim();
+    }
+    // 프록시 헤더 없으면, 서블릿 요청의 remote address를 사용
+    // ex) 127.0.0.1 or 0:0:0:0:0:0:0:1
+    return request.getRemoteAddr();
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,5 +77,7 @@ deokhugam:
       key: ${OCR_API_KEY:}
 
 logging:
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{requestId}] [%X{clientIp}] %logger{36} - %msg%n"
   level:
     root: info

--- a/src/test/java/com/team01/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/team01/deokhugam/comment/controller/CommentControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -421,5 +422,30 @@ public class CommentControllerTest {
 
     // when // then
     mockMvc.perform(get("/api/comments/{commentId}", commentId)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 시 응답 헤더에 X-Request-Id가 포함된다")
+  void get_comments_should_add_request_id_header() throws Exception {
+    // given
+    UUID reviewId = UUID.randomUUID();
+
+    CursorPageResponse<CommentDto> response =
+        new CursorPageResponse<>(List.of(), null, null, 0, 0, false);
+
+    given(
+            commentService.getComments(
+                eq(reviewId), any(CursorPageRequest.class), eq(SortDirection.DESC)))
+        .willReturn(response);
+
+    // when , then
+    mockMvc
+        .perform(
+            get("/api/comments")
+                .param("reviewId", reviewId.toString())
+                .param("direction", "DESC")
+                .param("limit", "50"))
+        .andExpect(status().isOk())
+        .andExpect(header().exists("X-Request-Id"));
   }
 }

--- a/src/test/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilterTest.java
+++ b/src/test/java/com/team01/deokhugam/global/filter/RequestMdcLoggingFilterTest.java
@@ -1,0 +1,75 @@
+package com.team01.deokhugam.global.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class RequestMdcLoggingFilterTest {
+  private final RequestMdcLoggingFilter filter = new RequestMdcLoggingFilter();
+
+  @Test
+  @DisplayName("필터 실행 중에는 MDC에 requestId, clientIp가 저장되고 응답 헤더에도 requestId가 추가된다")
+  void should_put_mdc_values_and_add_request_id_header() throws ServletException, IOException {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    request.addHeader("X-Forwarded-For", "203.0.113.10, 10.0.0.3");
+    request.setRemoteAddr("127.0.0.1");
+
+    FilterChain chain =
+        (req, res) -> {
+          // 필터 체인 내부에서는 MDC 값이 살아 있어야 한다.
+          String requestId = MDC.get(RequestMdcLoggingFilter.MDC_REQUEST_ID);
+          String clientIp = MDC.get(RequestMdcLoggingFilter.MDC_CLIENT_IP);
+
+          assertThat(requestId).isNotBlank();
+          assertThat(clientIp).isEqualTo("203.0.113.10");
+
+          // 응답 헤더에도 같은 requestId가 들어가 있어야 한다.
+          assertThat(
+                  ((MockHttpServletResponse) res)
+                      .getHeader(RequestMdcLoggingFilter.HEADER_REQUEST_ID))
+              .isEqualTo(requestId);
+        };
+
+    // when - 필터 한번 실행
+    filter.doFilter(request, response, chain);
+
+    // then
+    // 요청 처리가 끝난 뒤에는 MDC 값이 제거되어야 한다.
+    assertThat(MDC.get(RequestMdcLoggingFilter.MDC_REQUEST_ID)).isNull();
+    assertThat(MDC.get(RequestMdcLoggingFilter.MDC_CLIENT_IP)).isNull();
+
+    // 응답 헤더는 최종 응답에도 남아 있어야 한다.
+    assertThat(response.getHeader(RequestMdcLoggingFilter.HEADER_REQUEST_ID)).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("X-Forwarded-For가 없고 X-Real-IP가 있으면 X-Real-IP를 clientIp로 사용한다")
+  void should_use_x_real_ip_when_x_forwarded_for_is_missing() throws ServletException, IOException {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    request.addHeader("X-Real-IP", "192.168.0.10");
+    request.setRemoteAddr("127.0.0.1");
+
+    FilterChain chain =
+        (req, res) ->
+            assertThat(MDC.get(RequestMdcLoggingFilter.MDC_CLIENT_IP)).isEqualTo("192.168.0.10");
+
+    // when
+    filter.doFilter(request, response, chain);
+
+    // then
+    assertThat(MDC.get(RequestMdcLoggingFilter.MDC_CLIENT_IP)).isNull();
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #264 

## 📝 작업 내용

```java
HTTP 요청 들어옴
→ RequestMdcLoggingFilter 실행
→ requestId 생성
→ clientIp 추출
→ MDC에 저장
→ 컨트롤러/서비스/레포지토리 로그 실행
→ 로그마다 requestId, clientIp가 같이 찍힘
→ 요청 끝나면 MDC 비움
```

## 💡 변경 사항

-

## 🔍 테스트 방법

- CommentControllerTest 활용하여 테스트 진행하였습니다. 

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 모든 HTTP 요청에 고유한 추적 ID가 자동으로 부여되어 응답의 `X-Request-Id` 헤더를 통해 반환됩니다.
  * 시스템 전역의 로그 포맷이 업데이트되어 요청 ID와 클라이언트 IP 정보가 모든 로그 항목에 포함되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->