### PR TITLE
fix: 리뷰 목록 조회 시 책제목으로 검색기능 추가

### DIFF
--- a/src/main/java/com/team01/deokhugam/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/repository/ReviewRepositoryImpl.java
@@ -124,6 +124,10 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
       jpql.append(" join r.user u ");
     }
 
+    if (queryParts.requiresBookJoin()) {
+      jpql.append(" join r.book b ");
+    }
+
     jpql.append(queryParts.whereClause());
 
     TypedQuery<Long> query = em.createQuery(jpql.toString(), Long.class);
@@ -136,6 +140,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     StringBuilder whereClause = new StringBuilder(" where r.isDeleted = false ");
     Map<String, Object> params = new HashMap<>();
     boolean requiresUserJoin = false;
+    boolean requiresBookJoin = false;
 
     if (condition.userId() != null) {
       whereClause.append(" and r.user.id = :userId ");
@@ -149,18 +154,20 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
     if (condition.keyword() != null && !condition.keyword().isBlank()) {
       requiresUserJoin = true;
+      requiresBookJoin = true;
       whereClause.append(
           """
                and (
                  lower(u.nickname) like lower(:keyword) escape '\\'
                  or lower(r.content) like lower(:keyword) escape '\\'
+                 or lower(b.title) like lower(:keyword) escape '\\'
                )
               """
       );
       params.put("keyword", "%" + escapeLikeKeyword(condition.keyword()) + "%");
     }
 
-    return new QueryParts(whereClause.toString(), params, requiresUserJoin);
+    return new QueryParts(whereClause.toString(), params, requiresUserJoin, requiresBookJoin);
   }
 
   private UUID parseUuidCursor(String cursor) {
@@ -211,7 +218,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
   private record QueryParts(
       String whereClause,
       Map<String, Object> params,
-      boolean requiresUserJoin
+      boolean requiresUserJoin,
+      boolean requiresBookJoin
   ) {
 
   }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #281 

## 📝 작업 내용

- 리뷰 목록 조회 시, 책 제목으로도 검색이 가능하게 기능을 추가 했습니다.

## 💡 변경 사항

- 변경사항 1

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **개선 사항**
  * 키워드 검색 기능이 확대되어 리뷰 검색 시 도서 제목도 함께 검색됩니다. 사용자는 더욱 정확하고 포괄적인 검색 결과를 얻을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->