### PR TITLE
fix: 리뷰 유니크 속성 수정, 알림 추가

### DIFF
--- a/src/main/java/com/team01/deokhugam/dashboard/popularreview/service/PopularReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/dashboard/popularreview/service/PopularReviewServiceImpl.java
@@ -26,8 +26,12 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @Service
@@ -39,6 +43,7 @@ public class PopularReviewServiceImpl implements PopularReviewService {
   private final ReviewRepository reviewRepository;
   private final PopularReviewMapper popularReviewMapper;
   private final NotificationRepository notificationRepository;
+  private final PlatformTransactionManager transactionManager;
 
   @Override
   public void calculatePopularReviews(
@@ -136,21 +141,32 @@ public class PopularReviewServiceImpl implements PopularReviewService {
           String content = period + " 인기 리뷰 10위 안에 진입했습니다.";
 
           try {
-            boolean alreadyExists = notificationRepository.existsByReviewIdAndUserIdAndContent(
+            TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+            transactionTemplate.setPropagationBehavior(
+                TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+            transactionTemplate.executeWithoutResult(status -> {
+              boolean alreadyExists = notificationRepository.existsByReviewIdAndUserIdAndContent(
+                  review.getId(),
+                  reviewOwner.getId(),
+                  content
+              );
+
+              if (alreadyExists) {
+                return;
+              }
+
+              notificationRepository.save(new Notification(
+                  review,
+                  reviewOwner,
+                  content
+              ));
+            });
+          } catch (DataIntegrityViolationException e) {
+            log.info("인기 리뷰 알림 중복 생성 감지: reviewId={}, userId={}, period={}",
                 review.getId(),
                 reviewOwner.getId(),
-                content
-            );
-
-            if (alreadyExists) {
-              return;
-            }
-
-            notificationRepository.save(new Notification(
-                review,
-                reviewOwner,
-                content
-            ));
+                period);
           } catch (Exception e) {
             log.error("인기 리뷰 알림 생성 실패: reviewId={}, rank={}, period={}",
                 review.getId(),

--- a/src/main/java/com/team01/deokhugam/dashboard/popularreview/service/PopularReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/dashboard/popularreview/service/PopularReviewServiceImpl.java
@@ -9,8 +9,11 @@ import com.team01.deokhugam.dashboard.popularreview.entity.PopularReview;
 import com.team01.deokhugam.dashboard.popularreview.mapper.PopularReviewMapper;
 import com.team01.deokhugam.dashboard.popularreview.repository.PopularReviewRepository;
 import com.team01.deokhugam.global.enums.SortDirection;
+import com.team01.deokhugam.notification.entity.Notification;
+import com.team01.deokhugam.notification.repository.NotificationRepository;
 import com.team01.deokhugam.review.entity.Review;
 import com.team01.deokhugam.review.repository.ReviewRepository;
+import com.team01.deokhugam.user.entity.User;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -35,6 +38,7 @@ public class PopularReviewServiceImpl implements PopularReviewService {
   private final PopularReviewRepository popularReviewRepository;
   private final ReviewRepository reviewRepository;
   private final PopularReviewMapper popularReviewMapper;
+  private final NotificationRepository notificationRepository;
 
   @Override
   public void calculatePopularReviews(
@@ -123,6 +127,38 @@ public class PopularReviewServiceImpl implements PopularReviewService {
     }
 
     popularReviewRepository.saveAll(popularReviews);
+
+    popularReviews.stream()
+        .filter(popularReview -> popularReview.getRank() <= 10)
+        .forEach(popularReview -> {
+          Review review = popularReview.getReview();
+          User reviewOwner = review.getUser();
+          String content = period + " 인기 리뷰 10위 안에 진입했습니다.";
+
+          try {
+            boolean alreadyExists = notificationRepository.existsByReviewIdAndUserIdAndContent(
+                review.getId(),
+                reviewOwner.getId(),
+                content
+            );
+
+            if (alreadyExists) {
+              return;
+            }
+
+            notificationRepository.save(new Notification(
+                review,
+                reviewOwner,
+                content
+            ));
+          } catch (Exception e) {
+            log.error("인기 리뷰 알림 생성 실패: reviewId={}, rank={}, period={}",
+                review.getId(),
+                popularReview.getRank(),
+                period,
+                e);
+          }
+        });
 
     log.info("인기 리뷰 집계 완료: period={}, calculatedDate={}, savedCount={}",
         period, calculatedDate, popularReviews.size());

--- a/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/team01/deokhugam/notification/repository/NotificationRepository.java
@@ -4,10 +4,7 @@ import com.team01.deokhugam.notification.entity.Notification;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID>,
     NotificationRepositoryCustom {
@@ -17,4 +14,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   void deleteAllByIsReadTrueAndConfirmedAtBefore(OffsetDateTime cutoff);
 
   long countByUserId(UUID userId);
+
+  boolean existsByReviewIdAndUserIdAndContent(UUID reviewId, UUID userId, String content);
 }

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
@@ -8,6 +8,8 @@ import com.team01.deokhugam.global.exception.DeokhugamException;
 import com.team01.deokhugam.global.exception.ErrorCode;
 import com.team01.deokhugam.global.pagination.CursorPageResponse;
 import com.team01.deokhugam.global.pagination.CursorPaginationUtils;
+import com.team01.deokhugam.notification.dto.NotificationCreateRequest;
+import com.team01.deokhugam.notification.service.NotificationService;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
@@ -45,6 +47,7 @@ public class ReviewServiceImpl implements ReviewService {
   private final UserRepository userRepository;
   private final ReviewMapper reviewMapper;
   private final BookService bookService;
+  private final NotificationService notificationService;
 
   @Override
   @Transactional
@@ -276,6 +279,22 @@ public class ReviewServiceImpl implements ReviewService {
             ReviewLike reviewLike = new ReviewLike(review, user);
             reviewLikeRepository.save(reviewLike);
             review.increaseLikeCount();
+
+            if (!review.getUser().getId().equals(requestUserId)) {
+              try {
+                notificationService.create(
+                    new NotificationCreateRequest(
+                        review,
+                        user,
+                        "내가 작성한 리뷰에 좋아요가 추가되었습니다."
+                    )
+                );
+              } catch (Exception e) {
+                log.error("리뷰 좋아요 알림 생성 실패: reviewId={}, actorUserId={}",
+                    reviewId, requestUserId, e);
+              }
+            }
+
             log.info("리뷰 좋아요 추가: reviewId={}, requestUserId={}", reviewId, requestUserId);
 
             return new ReviewLikeDto(reviewId, requestUserId, true);

--- a/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/team01/deokhugam/review/service/ReviewServiceImpl.java
@@ -33,7 +33,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @Service
@@ -48,6 +51,7 @@ public class ReviewServiceImpl implements ReviewService {
   private final ReviewMapper reviewMapper;
   private final BookService bookService;
   private final NotificationService notificationService;
+  private final PlatformTransactionManager transactionManager;
 
   @Override
   @Transactional
@@ -282,11 +286,18 @@ public class ReviewServiceImpl implements ReviewService {
 
             if (!review.getUser().getId().equals(requestUserId)) {
               try {
-                notificationService.create(
-                    new NotificationCreateRequest(
-                        review,
-                        user,
-                        "내가 작성한 리뷰에 좋아요가 추가되었습니다."
+                TransactionTemplate transactionTemplate = new TransactionTemplate(
+                    transactionManager);
+                transactionTemplate.setPropagationBehavior(
+                    TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+                transactionTemplate.executeWithoutResult(status ->
+                    notificationService.create(
+                        new NotificationCreateRequest(
+                            review,
+                            user,
+                            "내가 작성한 리뷰에 좋아요가 추가되었습니다."
+                        )
                     )
                 );
               } catch (Exception e) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -96,6 +96,7 @@ CREATE TABLE IF NOT EXISTS notifications
 
 CREATE INDEX IF NOT EXISTS idx_notifications_user_read ON notifications (user_id, is_read);
 CREATE INDEX IF NOT EXISTS idx_notifications_review_id ON notifications (review_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_notifications_review_user_content ON notifications (review_id, user_id, content);
 
 CREATE TABLE IF NOT EXISTS review_likes
 (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -50,9 +50,10 @@ CREATE TABLE IF NOT EXISTS reviews
     updated_at    TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_reviews_books FOREIGN KEY (book_id) REFERENCES books (id) ON DELETE CASCADE,
-    CONSTRAINT fk_reviews_users FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
-    CONSTRAINT uk_reviews_book_user UNIQUE (book_id, user_id)
+    CONSTRAINT fk_reviews_users FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
     );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_reviews_active_book_user ON reviews (book_id, user_id) WHERE is_deleted = FALSE;
 
 CREATE INDEX IF NOT EXISTS idx_reviews_book_id ON reviews (book_id);
 CREATE INDEX IF NOT EXISTS idx_reviews_user_id ON reviews (user_id);

--- a/src/test/java/com/team01/deokhugam/dashboard/popularreview/service/PopularReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/dashboard/popularreview/service/PopularReviewServiceImplTest.java
@@ -1,0 +1,5 @@
+package com.team01.deokhugam.dashboard.popularreview.service;
+
+class PopularReviewServiceImplTest {
+
+}

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -17,6 +17,7 @@ import com.team01.deokhugam.book.service.BookService;
 import com.team01.deokhugam.global.enums.SortDirection;
 import com.team01.deokhugam.global.exception.DeokhugamException;
 import com.team01.deokhugam.global.exception.ErrorCode;
+import com.team01.deokhugam.notification.service.NotificationService;
 import com.team01.deokhugam.review.dto.CursorPageResponseReviewDto;
 import com.team01.deokhugam.review.dto.ReviewCreateRequest;
 import com.team01.deokhugam.review.dto.ReviewDto;
@@ -41,18 +42,25 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceImplTest {
+
+  @Mock
+  private BookService bookService;
+
+  @Mock
+  private NotificationService notificationService;
+
+  @Mock
+  private PlatformTransactionManager transactionManager;
 
   @Mock
   private ReviewRepository reviewRepository;
 
   @Mock
   private BookRepository bookRepository;
-
-  @Mock
-  private BookService bookService;
 
   @Mock
   private UserRepository userRepository;

--- a/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/team01/deokhugam/review/service/ReviewServiceImplTest.java
@@ -450,6 +450,9 @@ class ReviewServiceImplTest {
     given(reviewLikeRepository.findByReviewIdAndUserId(reviewId, requestUserId))
         .willReturn(Optional.empty());
 
+    given(review.getUser()).willReturn(user);
+    given(user.getId()).willReturn(requestUserId);
+
     ReviewLikeDto result = reviewServiceImpl.toggleLike(reviewId, requestUserId);
 
     verify(reviewLikeRepository).save(any(ReviewLike.class));


### PR DESCRIPTION
## 📌 관련 이슈

- closes #283 

## 📝 작업 내용

- 논리 삭제된 리뷰가 있어도 같은 도서에 리뷰를 다시 등록할 수 있도록 `reviews` 유니크 제약 수정
  - 기존 `book_id + user_id` 전체 유니크 제약 제거
  - `is_deleted = false` 조건부 유니크 인덱스 추가
- 다른 사용자가 내 리뷰에 좋아요를 누르면 알림 생성
- 내가 작성한 리뷰가 인기 리뷰 10위권에 진입하면 알림 생성
- 인기 리뷰 10위권 알림 중복 생성 방지
  - `reviewId + userId + content` 기준으로 기존 알림 존재 여부 확인
- 알림 생성 실패 시 기존 좋아요/집계 흐름이 중단되지 않도록 예외 처리

## 💡 변경 사항


## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인기 리뷰 10위 진입 시 작성자에게 알림 발송
  * 리뷰 좋아요 발생 시 작성자에게 알림 발송

* **버그 수정**
  * 삭제된 리뷰를 고려한 고유성 제약 개선(부분 인덱스)
  * 알림 중복 생성을 방지하는 고유 제약 추가

* **테스트**
  * 인기 리뷰 관련 테스트 클래스 추가 및 리뷰 좋아요 테스트 보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->