### PR TITLE
fix: 인기 리뷰 응답의 createdAt을 리뷰 원본 작성일로 매핑

### DIFF
--- a/src/main/java/com/team01/deokhugam/dashboard/popularreview/mapper/PopularReviewMapper.java
+++ b/src/main/java/com/team01/deokhugam/dashboard/popularreview/mapper/PopularReviewMapper.java
@@ -24,7 +24,7 @@ public interface PopularReviewMapper {
   @Mapping(target = "reviewContent", source = "review.content")
   @Mapping(target = "reviewRating", source = "review.rating")
   @Mapping(target = "period", source = "period")
-  @Mapping(target = "createdAt", source = "createdAt")
+  @Mapping(target = "createdAt", source = "review.createdAt")
   @Mapping(target = "rank", source = "rank")
   @Mapping(target = "score", source = "score")
   @Mapping(target = "likeCount", source = "likeCount")


### PR DESCRIPTION
## 📌 관련 이슈

- closes #290 

## 📝 작업 내용

- PopularReviewMapper에서 응답의 createdAt 소스를 PopularReview의 createdAt(랭킹 산출 시각)으로 매핑하고 있어, API 응답에 실제 리뷰 작성일이 아닌 인기 랭킹 집계 시점이 전달되는 문제 수정

## 💡 변경 사항

- `PopularReviewMapper.java`
  - `@Mapping(target = "createdAt", source = "createdAt")` 
    -> `@Mapping(target = "createdAt", source = "review.createdAt")`
  - PopularReview 엔티티 자신의 `createdAt`(랭킹 집계 시각) 대신, 연관된 원본 Review 엔티티의 `createdAt`(리뷰 작성 시각)을 매핑하도록 변경

## 🔍 테스트 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<img width="1025" height="840" alt="image" src="https://github.com/user-attachments/assets/3236fd5f-6627-4eda-a9fe-2d071da85cc4" />

```
백엔드 API 응답 (PopularReviewDto)
  │ createdAt = "2026-04-30T18:59:56Z" <- (배치 실행 시각이 들어왔던 것이 문제의 원인)
  ▼
PopularReviews.tsx 
  │ response.content 그대로 popularReviews 상태에 저장
  ▼
ReviewCard.tsx
  │ review.createdAt → reviewData.createdAt 으로 매핑 후 자식에 전달
  ▼
ReviewContent.tsx
  │ formatDate(createdAt) → "2026.04.30" 으로 화면에 출력
  ▼
[화면]
```