### PR TITLE
refactor: 인기도서 대시보드 이미지 안보이는 문제 수정

### DIFF
--- a/src/main/java/com/team01/deokhugam/dashboard/popularbook/dto/PopularBookDto.java
+++ b/src/main/java/com/team01/deokhugam/dashboard/popularbook/dto/PopularBookDto.java
@@ -24,13 +24,14 @@ public class PopularBookDto {
   private double rating;
   private OffsetDateTime createdAt;
 
-  public static PopularBookDto from(PopularBook popularBook) {
+  public static PopularBookDto from(PopularBook popularBook, String thumbnailUrl) {
     return PopularBookDto.builder()
         .id(popularBook.getId())
         .bookId(popularBook.getBook().getId())
         .title(popularBook.getBook().getTitle())
         .author(popularBook.getBook().getAuthor())
-        .thumbnailUrl(popularBook.getBook().getThumbnailUrl())
+        // 원본 key가 아닌, local/s3 환경에 맞게 변환된 URL사용
+        .thumbnailUrl(thumbnailUrl)
         .period(popularBook.getPeriodType())
         .rank(popularBook.getRank())
         .score(popularBook.getScore())

--- a/src/main/java/com/team01/deokhugam/dashboard/popularbook/service/PopularBookService.java
+++ b/src/main/java/com/team01/deokhugam/dashboard/popularbook/service/PopularBookService.java
@@ -1,6 +1,7 @@
 package com.team01.deokhugam.dashboard.popularbook.service;
 
 import com.team01.deokhugam.batch.common.DashboardPeriod;
+import com.team01.deokhugam.book.storage.ThumbnailStorage;
 import com.team01.deokhugam.dashboard.popularbook.dto.PopularBookDto;
 import com.team01.deokhugam.dashboard.popularbook.entity.PopularBook;
 import com.team01.deokhugam.dashboard.popularbook.repository.PopularBookRepository;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PopularBookService {
 
   private final PopularBookRepository popularBookRepository;
+  private final ThumbnailStorage thumbnailStorage;
 
   // 인기 도서 조회
   @Transactional(readOnly = true)
@@ -40,8 +42,17 @@ public class PopularBookService {
     boolean hasNext = popularBooks.size() > normalizedLimit;
 
     // 목록 생성
+    // local/s3 환경에 맞는 실제 접근 가능한 URL로 변환
     List<PopularBookDto> content =
-        popularBooks.stream().limit(normalizedLimit).map(PopularBookDto::from).toList();
+        popularBooks.stream()
+            .limit(normalizedLimit)
+            .map(
+                popularBook ->
+                    PopularBookDto.from(
+                        popularBook,
+                        thumbnailStorage.generatePresignUrl(
+                            popularBook.getBook().getThumbnailUrl())))
+            .toList();
 
     String nextCursor = null;
     OffsetDateTime nextAfter = null;

--- a/src/test/java/com/team01/deokhugam/dashboard/popularbook/service/PopularBookServiceTest.java
+++ b/src/test/java/com/team01/deokhugam/dashboard/popularbook/service/PopularBookServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.team01.deokhugam.batch.common.DashboardPeriod;
 import com.team01.deokhugam.book.entity.Book;
+import com.team01.deokhugam.book.storage.ThumbnailStorage;
 import com.team01.deokhugam.dashboard.popularbook.dto.PopularBookDto;
 import com.team01.deokhugam.dashboard.popularbook.entity.PopularBook;
 import com.team01.deokhugam.dashboard.popularbook.repository.PopularBookRepository;
@@ -25,7 +26,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class PopularBookServiceTest {
+
   @Mock private PopularBookRepository popularBookRepository;
+  @Mock private ThumbnailStorage thumbnailStorage;
 
   @InjectMocks private PopularBookService popularBookService;
 
@@ -40,6 +43,12 @@ class PopularBookServiceTest {
     PopularBook pb1 = createPopularBook(1, time1);
     PopularBook pb2 = createPopularBook(2, time2);
     PopularBook pb3 = createPopularBook(3, time3);
+
+    // 썸네일 원본 key를 실제 접근 가능한 URL로 변환
+    given(thumbnailStorage.generatePresignUrl("thumbnail-1.jpg"))
+        .willReturn("/qa-images/thumbnail-1.jpg");
+    given(thumbnailStorage.generatePresignUrl("thumbnail-2.jpg"))
+        .willReturn("/qa-images/thumbnail-2.jpg");
 
     // limit 2면 3개 반환
     given(
@@ -60,6 +69,8 @@ class PopularBookServiceTest {
     assertThat(result.nextCursor()).isEqualTo("2");
     assertThat(result.nextAfter()).isEqualTo(time2);
     assertThat(result.totalElements()).isEqualTo(3);
+    assertThat(result.content().get(0).getThumbnailUrl()).isEqualTo("/qa-images/thumbnail-1.jpg");
+    assertThat(result.content().get(1).getThumbnailUrl()).isEqualTo("/qa-images/thumbnail-2.jpg");
   }
 
   @Test
@@ -71,6 +82,11 @@ class PopularBookServiceTest {
 
     PopularBook pb1 = createPopularBook(1, time1);
     PopularBook pb2 = createPopularBook(2, time2);
+
+    given(thumbnailStorage.generatePresignUrl("thumbnail-1.jpg"))
+        .willReturn("/qa-images/thumbnail-1.jpg");
+    given(thumbnailStorage.generatePresignUrl("thumbnail-2.jpg"))
+        .willReturn("/qa-images/thumbnail-2.jpg");
 
     given(
             popularBookRepository.findAllByCursor(
@@ -90,6 +106,8 @@ class PopularBookServiceTest {
     assertThat(result.nextCursor()).isNull();
     assertThat(result.nextAfter()).isNull();
     assertThat(result.totalElements()).isEqualTo(2);
+    assertThat(result.content().get(0).getThumbnailUrl()).isEqualTo("/qa-images/thumbnail-1.jpg");
+    assertThat(result.content().get(1).getThumbnailUrl()).isEqualTo("/qa-images/thumbnail-2.jpg");
   }
 
   private PopularBook createPopularBook(int rank, OffsetDateTime createdAt) {
@@ -101,7 +119,11 @@ class PopularBookServiceTest {
             .publisher("출판사")
             .publishedDate(LocalDate.of(2026, 4, 1))
             .isbn("isbn-" + rank)
+            .thumbnailUrl("thumbnail-" + rank + ".jpg")
             .build();
+
+    // 현재 Book 생성자에서는 thumbnailUrl이 builder 값만으로는 세팅되지 않아서 테스트에서 직접 넣어준다.
+    book.addThumbnail("thumbnail-" + rank + ".jpg");
 
     ReflectionTestUtils.setField(book, "id", UUID.randomUUID());
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #301 

## 📝 작업 내용

- DB 값(raw key) 그대로 응답하는 것에서, DB 값(raw key)을 ThumbnailStorage로 변환한 뒤 응답하게 변경하였습니다.

## 💡 변경 사항

- 

## 🔍 테스트 방법

- 방법

## 📸 스크린샷 (선택)

## 💬 참고 사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 인기 도서 썸네일 이미지의 접근성이 개선되었습니다. 썸네일 URL이 사전 서명된 형식으로 처리되어 환경에 맞게 안정적으로 이미지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->